### PR TITLE
:sparkles: Feat: 모달용 버튼 구현

### DIFF
--- a/src/components/Buttons/ModalBtn.tsx
+++ b/src/components/Buttons/ModalBtn.tsx
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+const ModalBtn = ({ handler }) => {
+  return <Container onClick={handler}>신청하기</Container>;
+};
+
+export default ModalBtn;
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 24rem;
+  height: 3.5em;
+  border-radius: 8px;
+  background-color: ${props => props.theme.primary};
+  color: ${props => props.theme.white};
+`;


### PR DESCRIPTION
## PR 타입

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 업데이트
- [ ] 사소한 수정

<br />

## PR 요약

모달용 버튼을 구현했습니다.
px단위 대신 rem 상대 단위를 사용하였습니다.