### PR TITLE
:lipstick: Desgin: 메인 헤더 UI 구현 및 type 폴더 생성

### DIFF
--- a/src/components/MainHeader.tsx
+++ b/src/components/MainHeader.tsx
@@ -1,12 +1,37 @@
+import { MdOutlineLocalHospital } from 'react-icons/md';
 import styled from 'styled-components';
 
 const MainHeader = () => {
-  return <Container>MainHeader</Container>;
+  return (
+    <Container>
+      <HosPital>
+        <MdOutlineLocalHospital />
+        <span className="hospital-name">연세 세브란스 병원</span>
+      </HosPital>
+    </Container>
+  );
 };
 
 export default MainHeader;
 
 const Container = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
   width: 100%;
-  height: 2rem;
+  height: 4rem;
+  color: ${props => props.theme.gray};
+  font-weight: 500;
+`;
+
+const HosPital = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 2rem;
+  svg {
+    width: 1.2rem;
+    height: 1.2rem;
+  }
 `;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,0 +1,23 @@
+// 프로젝트에 사용되는 types 정리 //
+
+// 사용자 데이터
+interface UserData {
+  id: number;
+  emp_no: number;
+  name: string;
+  email: string;
+  phone: string;
+  hospital_id: number;
+  dept_id: number;
+  level: string;
+  auth: string;
+  status: string;
+  annual: number;
+  duty: number;
+  profile_image_url: string;
+  hiredate: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export { UserData };


### PR DESCRIPTION
## PR 타입

- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 코드 업데이트
- [x] 사소한 수정

<br />

## PR 요약

- 메인 헤더 내 병원명 UI 구현
- type 전용 폴더 생성

<br />

## 코드 참고사항

병원명을 텍스트 태그로 하드코딩 해둔 상태로 추후 데이터 바인딩으로 수정 예정입니다.