### PR TITLE
✨ Feat: 모달 제작 및 연결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,18 @@ import { Outlet } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 import themes from '@/styles/Themes.ts';
 import GlobalStyle from '@/styles/GlobalStyle.ts';
+import { RecoilRoot } from 'recoil';
+import { Modal } from '@/components/Modals/Modal';
 
 const App = () => {
   return (
-    <ThemeProvider theme={themes}>
-      <GlobalStyle />
-      <Outlet />
-    </ThemeProvider>
+    <RecoilRoot>
+      <ThemeProvider theme={themes}>
+        <GlobalStyle />
+        <Modal />
+        <Outlet />
+      </ThemeProvider>
+    </RecoilRoot>
   );
 };
 

--- a/src/components/Buttons/AnnualBtn.tsx
+++ b/src/components/Buttons/AnnualBtn.tsx
@@ -1,7 +1,17 @@
+import { useModal } from '@/hooks/useModal';
 import styled from 'styled-components';
+import { RequestModal } from '../Modals/RequestModal';
 
 const AnnualBtn = () => {
-  return <Container>휴가 신청</Container>;
+  const { openModal } = useModal();
+
+  const modalData = {
+    isOpen: true,
+    title: '휴가 신청',
+    content: <RequestModal type={'annual'} />,
+  };
+
+  return <Container onClick={() => openModal(modalData)}>휴가 신청</Container>;
 };
 
 export default AnnualBtn;

--- a/src/components/Buttons/DutyBtn.tsx
+++ b/src/components/Buttons/DutyBtn.tsx
@@ -1,7 +1,17 @@
 import styled from 'styled-components';
+import { useModal } from '@/hooks/useModal';
+import { RequestModal } from '../Modals/RequestModal';
 
 const DutyBtn = () => {
-  return <Container>당직 수정</Container>;
+  const { openModal } = useModal();
+
+  const modalData = {
+    isOpen: true,
+    title: '당직 수정 신청',
+    content: <RequestModal type={'duty'} />,
+  };
+
+  return <Container onClick={() => openModal(modalData)}>당직 수정</Container>;
 };
 
 export default DutyBtn;

--- a/src/components/Calendar/CalendarBody.tsx
+++ b/src/components/Calendar/CalendarBody.tsx
@@ -2,6 +2,9 @@ import { useEffect, useState } from 'react';
 import dayjs from 'dayjs';
 import { styled } from 'styled-components';
 import axios from 'axios';
+import { useModal } from '@/hooks/useModal';
+import { CalAnnualModal } from '../Modals/CalAnnualModal';
+import { CalDutylModal } from '../Modals/CalDutyModal';
 
 interface Calendar {
   id: number;
@@ -57,11 +60,32 @@ const CalendarBody = ({
     getUser();
   }, []);
 
+  const { openModal } = useModal();
+
   const handleClickDuty = (date: dayjs.Dayjs) => {
+    const clickDate = date.format('YYYY-MM-DD');
+
+    const modalData = {
+      isOpen: true,
+      title: '금일 응급실 당직',
+      content: <CalDutylModal date={clickDate} />,
+    };
+
+    openModal(modalData);
+
     console.log('당직클릭', date.format('YYYY-MM-DD'));
   };
 
   const handleClickAnnual = (date: dayjs.Dayjs) => {
+    const clickDate = date.format('YYYY-MM-DD');
+
+    const modalData = {
+      isOpen: true,
+      title: '금일 휴가 인원',
+      content: <CalAnnualModal date={clickDate} />,
+    };
+
+    openModal(modalData);
     console.log('휴가클릭', date.format('YYYY-MM-DD'));
   };
 

--- a/src/components/Modals/CalAnnualModal.tsx
+++ b/src/components/Modals/CalAnnualModal.tsx
@@ -1,0 +1,39 @@
+import { styled } from 'styled-components';
+
+export const CalAnnualModal = ({ date }) => {
+  return (
+    <Container>
+      {date}
+      <TableContainer>
+        <tr>
+          <td>No.</td>
+          <td>이름</td>
+          <td>파트</td>
+          <td>직급</td>
+          <td>연락처</td>
+        </tr>
+        <tr>
+          <td>1</td>
+          <td>나영석</td>
+          <td>소아과</td>
+          <td>인턴</td>
+          <td>010-92982-1828</td>
+        </tr>
+      </TableContainer>
+      {/* <InputContainer>
+        <div className="inputTitle">신청 사유</div>
+        <textarea className="reasonBox" />
+      </InputContainer> */}
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+`;
+const TableContainer = styled.table`
+  width: 100%;
+`;

--- a/src/components/Modals/CalDutyModal.tsx
+++ b/src/components/Modals/CalDutyModal.tsx
@@ -1,0 +1,47 @@
+import { styled } from 'styled-components';
+
+export const CalDutylModal = ({ date }) => {
+  return (
+    <Container>
+      {date}
+      <div>
+        <div></div>
+        <div>김땡땡</div>
+      </div>
+      <InputContainer>
+        <div className="inputTitle">특이사항</div>
+        <textarea className="reasonBox" />
+      </InputContainer>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 32px;
+`;
+const InputContainer = styled.div`
+  .inputTitle {
+    color: ${props => props.theme.gray};
+    margin-bottom: 8px;
+    font-family: 'ABeeZee', sans-serif;
+  }
+  .reasonBox {
+    box-sizing: border-box;
+    height: 92px;
+    width: 320px;
+    border: 1px solid ${props => props.theme.gray};
+    border-radius: 8px;
+    padding: 16px;
+    transition: all 0.3s;
+    resize: none;
+    &:focus {
+      outline: none;
+      border: 1px solid ${props => props.theme.secondary};
+      box-shadow: 0 0 6px 3px rgba(156, 184, 255, 0.3);
+    }
+  }
+`;

--- a/src/components/Modals/Modal.tsx
+++ b/src/components/Modals/Modal.tsx
@@ -1,0 +1,67 @@
+import styled from 'styled-components';
+import { useModal } from '@/hooks/useModal';
+import { GrClose } from 'react-icons/gr';
+
+export const Modal = () => {
+  const { modalDataState, closeModal } = useModal();
+
+  return (
+    <>
+      {modalDataState.isOpen && (
+        <ModalContainer>
+          <ModalBody>
+            <ModalCloseButton onClick={closeModal}>
+              <GrClose />
+            </ModalCloseButton>
+            <ModalContent>
+              <ModalTitle>{modalDataState.title}</ModalTitle>
+              {modalDataState.content}
+            </ModalContent>
+          </ModalBody>
+        </ModalContainer>
+      )}
+    </>
+  );
+};
+
+export const ModalContainer = styled.div`
+  position: fixed;
+  z-index: 9;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+export const ModalBody = styled.div`
+  box-sizing: border-box;
+  min-height: 500px;
+  width: 550px;
+  color: ${props => props.theme.black};
+  background-color: ${props => props.theme.white};
+  border-radius: 8px;
+  padding: 46px 46px 56px 46px;
+`;
+export const ModalContent = styled.div`
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  padding: 20px 0 60px 0;
+  gap: 32px;
+`;
+
+export const ModalTitle = styled.div`
+  font-weight: bold;
+  font-size: 24px;
+  text-align: center;
+  margin-bottom: 16px;
+`;
+export const ModalCloseButton = styled.div`
+  cursor: pointer;
+  font-size: 16px;
+  text-align: right;
+`;

--- a/src/components/Modals/Modal.tsx
+++ b/src/components/Modals/Modal.tsx
@@ -58,7 +58,7 @@ export const ModalTitle = styled.div`
   font-weight: bold;
   font-size: 24px;
   text-align: center;
-  margin-bottom: 16px;
+  margin-bottom: 8px;
 `;
 export const ModalCloseButton = styled.div`
   cursor: pointer;

--- a/src/components/Modals/RequestModal.tsx
+++ b/src/components/Modals/RequestModal.tsx
@@ -1,0 +1,58 @@
+import { styled } from 'styled-components';
+import Btn from '@/components/Buttons/Btn';
+
+export const RequestModal = ({ type }) => {
+  return (
+    <Container>
+      <InputContainer>
+        <div className="inputTitle">{type === 'duty' ? '기준 날짜' : '휴가 시작일'}</div>
+        <input type="date" />
+      </InputContainer>
+      <InputContainer>
+        <div className="inputTitle">{type === 'duty' ? '변경 날짜' : '휴가 종료일'}</div>
+        <input type="date" />
+      </InputContainer>
+      {type === 'annual' && (
+        <InputContainer>
+          <div className="inputTitle">신청 사유</div>
+          <textarea className="reasonBox" />
+        </InputContainer>
+      )}
+      <Btn content={'신청하기'} />
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 32px;
+  button {
+    margin-top: 24px;
+  }
+`;
+
+const InputContainer = styled.div`
+  .inputTitle {
+    color: ${props => props.theme.gray};
+    margin-bottom: 8px;
+    font-family: 'ABeeZee', sans-serif;
+  }
+  .reasonBox {
+    box-sizing: border-box;
+    height: 92px;
+    width: 320px;
+    border: 1px solid ${props => props.theme.gray};
+    border-radius: 8px;
+    padding: 16px;
+    transition: all 0.3s;
+    resize: none;
+    &:focus {
+      outline: none;
+      border: 1px solid ${props => props.theme.secondary};
+      box-shadow: 0 0 6px 3px rgba(156, 184, 255, 0.3);
+    }
+  }
+`;

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,25 @@
+import { ModalType, modalState } from '@/states/stateModal';
+import { useCallback } from 'react';
+import { useRecoilState } from 'recoil';
+
+export const useModal = () => {
+  const [modalDataState, setModalDataState] = useRecoilState(modalState);
+
+  const closeModal = useCallback(
+    () =>
+      setModalDataState(prev => {
+        return { ...prev, isOpen: false };
+      }),
+    [setModalDataState],
+  );
+  const openModal = useCallback(
+    ({ title, content }: ModalType) =>
+      setModalDataState({
+        isOpen: true,
+        title: title,
+        content: content,
+      }),
+    [setModalDataState],
+  );
+  return { modalDataState, closeModal, openModal };
+};

--- a/src/states/stateModal.tsx
+++ b/src/states/stateModal.tsx
@@ -1,0 +1,16 @@
+import { atom } from 'recoil';
+
+export type ModalType = {
+  isOpen: boolean;
+  title: string;
+  content: JSX.Element | string;
+};
+
+export const modalState = atom<ModalType>({
+  key: 'modalState',
+  default: {
+    isOpen: false,
+    title: '',
+    content: '',
+  },
+});


### PR DESCRIPTION
## PR 타입

- [X] 기능 추가
- [ ] 버그 수정
- [ ] 코드 업데이트
- [ ] 사소한 수정

<br />

## PR 요약
Recoil, Custom Hook(`useModal.ts`)를 이용하여 모달을 사용합니다.

<br />

## 변경사항
1. `stateModal.tsx `
recoil을 사용하여 modal state를 관리합니다.

2. `useModal.ts` 커스텀 훅 사용
커스텀 훅을 만들어 컴포넌트 내에서 훅을 사용하여 recoil 데이터를 쉽게 다룹니다.

3. Modal 폴더
폴더 내의 `Modal.tsx`는 모달의 기본 디자인이며, 불러오는 데이터마다 안의 `content`가 변경됩니다.

### 기존 컴포넌트 변경사항
1. `CalendarBody.tsx`
당직, 휴가 인원 클릭 시 모달을 띄울 수 있도록 기존 `handleClickAnnual`, `handleClickDuty`에 모달을 연결 했습니다.

2. Button
`DutyBtn.tsx`, `AnnualBtn.tsx` 두 컴포넌트 내에 모달을 연결했습니다.

<br />

## 코드 참고사항
> 참고! 캘린더와 연결되어있는 모달은 아직 ui가 완성되지 않았습니다. 
### Modal 사용
```  
const { openModal } = useModal();
//모달 훅 불러오기

    const modalData = {
      isOpen: true, //모달의 isOpen 값을 변경해줍니다.
      title: '금일 응급실 당직', //모달의 제목을 설정합니다.
      content: <CalDutylModal date={clickDate} />, //불러올 모달을 컴포넌트로 넘겨줍니다.
    };
//모달 데이터 담기

    openModal(modalData);
//모달 훅에 모달 데이터를 넘겨줍니다.
```




