### PR TITLE
✨ Feat: 로그인 api 연결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react-router": "^6.14.2",
         "react-router-dom": "^6.14.2",
         "recoil": "^0.7.7",
+        "recoil-persist": "^5.1.0",
         "styled-components": "^6.0.5"
       },
       "devDependencies": {
@@ -4455,6 +4456,14 @@
         }
       }
     },
+    "node_modules/recoil-persist": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-5.1.0.tgz",
+      "integrity": "sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==",
+      "peerDependencies": {
+        "recoil": "^0.7.2"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -7973,6 +7982,12 @@
       "requires": {
         "hamt_plus": "1.0.2"
       }
+    },
+    "recoil-persist": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-5.1.0.tgz",
+      "integrity": "sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==",
+      "requires": {}
     },
     "regenerate": {
       "version": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-router": "^6.14.2",
     "react-router-dom": "^6.14.2",
     "recoil": "^0.7.7",
+    "recoil-persist": "^5.1.0",
     "styled-components": "^6.0.5"
   },
   "devDependencies": {

--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -10,7 +10,7 @@ import DutyBtn from '@/components/Buttons/DutyBtn';
 import { hospitalDecode } from '@/utils/decode';
 import { logout } from '@/lib/api';
 import { useSetRecoilState } from 'recoil';
-import { LoginState, UserState, authTokenState } from '@/states/stateLogin';
+import { LoginState, UserState } from '@/states/stateLogin';
 
 interface UserData {
   id: number;
@@ -69,7 +69,6 @@ const SideBar = () => {
   const [isSubMenuOpen, setIsSubMenuOpen] = useState(false);
   const [isMyPageActive, setIsMyPageActive] = useState('false');
   const setIsLoggedIn = useSetRecoilState(LoginState);
-  const setAuthToken = useSetRecoilState(authTokenState);
   const setUserState = useSetRecoilState(UserState);
 
   const navigate = useNavigate();
@@ -123,7 +122,6 @@ const SideBar = () => {
   const handleClickLogout = async () => {
     await logout();
     localStorage.removeItem('authToken');
-    setAuthToken(null);
     setIsLoggedIn(false);
     setUserState('');
     navigate('/login');

--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -8,6 +8,9 @@ import { FaRegPaperPlane } from 'react-icons/fa';
 import AnnualBtn from '@/components/Buttons/AnnualBtn';
 import DutyBtn from '@/components/Buttons/DutyBtn';
 import { hospitalDecode } from '@/utils/decode';
+import { logout } from '@/lib/api';
+import { useSetRecoilState } from 'recoil';
+import { LoginState, UserState, authTokenState } from '@/states/stateLogin';
 
 interface UserData {
   id: number;
@@ -65,6 +68,9 @@ const SideBar = () => {
   const [User, setUser] = useState<UserData>(initialUserData);
   const [isSubMenuOpen, setIsSubMenuOpen] = useState(false);
   const [isMyPageActive, setIsMyPageActive] = useState('false');
+  const setIsLoggedIn = useSetRecoilState(LoginState);
+  const setAuthToken = useSetRecoilState(authTokenState);
+  const setUserState = useSetRecoilState(UserState);
 
   const navigate = useNavigate();
 
@@ -114,8 +120,12 @@ const SideBar = () => {
     setIsMyPageActive('true');
   };
 
-  const handleClickLogout = () => {
-    //토큰 받아오기 성공 이후 토큰날리기 작업 추가 필요
+  const handleClickLogout = async () => {
+    await logout();
+    localStorage.removeItem('authToken');
+    setAuthToken(null);
+    setIsLoggedIn(false);
+    setUserState('');
     navigate('/login');
   };
 

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -10,9 +10,6 @@ import {
   EditDutyBody,
 } from '@/lib/types';
 
-const token =
-  'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJqdW5laGVlQGRyY2FsLmNvbSIsInBhc3N3b3JkIjoiJDJhJDEwJElVdUMzLlAzYVJ0RUcwZ2QxNWdaUy5tam9BemdWYjdvbmdYTWdXN3c1WnVVZkVtTlA3QVBTIiwiYXV0aCI6IlVTRVIiLCJpZCI6MTEsImV4cCI6MTY5MTQwNzE3NywidXNlcm5hbWUiOiLquYDspIDtnawiLCJzdGF0dXMiOiJBUFBST1ZFRCJ9.6SYyop3cB2OuksAfp-_EfawM7eA0taaGx5E-vJYjm0COHv4DVhEfr4DjmzTT5giK4U1Pq_7Z2I6FRnqgYCg7FA';
-
 const instance = axios.create({
   baseURL: 'http://fastcampus-mini-project-env.eba-khrscmx7.ap-northeast-2.elasticbeanstalk.com',
   headers: {
@@ -20,11 +17,14 @@ const instance = axios.create({
   },
 });
 
+const authToken = localStorage.getItem('authToken');
+const token = authToken || '';
+
 const authInstance = axios.create({
   baseURL: 'http://fastcampus-mini-project-env.eba-khrscmx7.ap-northeast-2.elasticbeanstalk.com',
   headers: {
     'Content-Type': 'application/json',
-    Authorization: `Bearer ${token}`,
+    Authorization: `${token}`,
   },
 });
 
@@ -32,7 +32,7 @@ const authInstance = axios.create({
 export const login = async (body: LoginBody) => {
   try {
     const res = await instance.post('/user/login', body);
-    return res.data;
+    return res;
   } catch (error) {
     console.log('로그인 실패', error);
   }

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -1,15 +1,24 @@
 import CalendarHeader from '@/components/Calendar/CalendarHeader';
 import { styled } from 'styled-components';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import dayjs from 'dayjs';
 import CalendarBody from '@/components/Calendar/CalendarBody';
 import CalendarList from '@/components/Calendar/CalendarList';
+import { useRecoilValue } from 'recoil';
+import { LoginState } from '@/states/stateLogin';
+import { useNavigate } from 'react-router';
 
 const Calendar = () => {
   const [currentMonth, setCurrentMonth] = useState(dayjs());
   const [toggleButton, settoggleButton] = useState(true);
   const [dutyActive, setdutyActive] = useState(false);
   const [annualActive, setannualActive] = useState(false);
+  const isLoggedIn = useRecoilValue(LoginState);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    !isLoggedIn && navigate('/');
+  }, []);
 
   const prevMonth = () => {
     setCurrentMonth(prevMonth => prevMonth.subtract(1, 'month'));

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -17,7 +17,8 @@ const Calendar = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    !isLoggedIn && navigate('/');
+    !isLoggedIn && navigate('/login');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const prevMonth = () => {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -6,8 +6,8 @@ import { useForm } from 'react-hook-form';
 import { FiAlertCircle } from 'react-icons/fi';
 import { postLogin } from '@/lib/api/miniAPI';
 import { useEffect, useState } from 'react';
-import { LoginState } from '@/states/stateLogin';
-import { useRecoilState } from 'recoil';
+import { LoginState, UserState } from '@/states/stateLogin';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 
 type FormData = {
   email: string;
@@ -17,6 +17,7 @@ type FormData = {
 const Login = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const setUserState = useSetRecoilState(UserState);
   const [isLoggedIn, setIsLoggedIn] = useRecoilState(LoginState);
   const navigate = useNavigate();
 
@@ -27,6 +28,7 @@ const Login = () => {
     formState: { errors },
   } = useForm<FormData>();
 
+  //로그인 된 상태로 /login 접속시 메인으로 강제 이동
   useEffect(() => {
     isLoggedIn && navigate('/');
   }, []);
@@ -43,11 +45,12 @@ const Login = () => {
     } else {
       //API호출
       console.log(data);
-      await postLogin({
+      const result = await postLogin({
         email,
         password,
       });
       setIsLoggedIn(true);
+      setUserState(result);
       navigate('/');
     }
   };

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -5,7 +5,9 @@ import SignUpValidation from '@/lib/Validation/validation';
 import { useForm } from 'react-hook-form';
 import { FiAlertCircle } from 'react-icons/fi';
 import { postLogin } from '@/lib/api/miniAPI';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { LoginState } from '@/states/stateLogin';
+import { useRecoilState } from 'recoil';
 
 type FormData = {
   email: string;
@@ -15,13 +17,19 @@ type FormData = {
 const Login = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [isLoggedIn, setIsLoggedIn] = useRecoilState(LoginState);
   const navigate = useNavigate();
+
   const {
     register,
     handleSubmit,
     setError,
     formState: { errors },
   } = useForm<FormData>();
+
+  useEffect(() => {
+    isLoggedIn && navigate('/');
+  }, []);
 
   const onSubmit = async (data: FormData) => {
     const validationErrors = SignUpValidation(data);
@@ -39,6 +47,7 @@ const Login = () => {
         email,
         password,
       });
+      setIsLoggedIn(true);
       navigate('/');
     }
   };

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -4,6 +4,8 @@ import Btn from '@/components/Buttons/Btn';
 import SignUpValidation from '@/lib/Validation/validation';
 import { useForm } from 'react-hook-form';
 import { FiAlertCircle } from 'react-icons/fi';
+import { postLogin } from '@/lib/api/miniAPI';
+import { useState } from 'react';
 
 type FormData = {
   email: string;
@@ -11,6 +13,8 @@ type FormData = {
 };
 
 const Login = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
   const navigate = useNavigate();
   const {
     register,
@@ -21,13 +25,20 @@ const Login = () => {
 
   const onSubmit = async (data: FormData) => {
     const validationErrors = SignUpValidation(data);
+    setEmail(data.email);
+    setPassword(data.password);
 
     if (Object.keys(validationErrors).length > 0) {
       Object.entries(validationErrors).forEach(([field, message]) => {
         setError(field, { type: 'manual', message });
       });
     } else {
+      //API호출
       console.log(data);
+      await postLogin({
+        email,
+        password,
+      });
       navigate('/');
     }
   };

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -4,54 +4,57 @@ import Btn from '@/components/Buttons/Btn';
 import SignUpValidation from '@/lib/Validation/validation';
 import { useForm } from 'react-hook-form';
 import { FiAlertCircle } from 'react-icons/fi';
-import { postLogin } from '@/lib/api/miniAPI';
 import { useEffect, useState } from 'react';
-import { LoginState, UserState } from '@/states/stateLogin';
-import { useRecoilState, useSetRecoilState } from 'recoil';
-
-type FormData = {
-  email: string;
-  password: string;
-};
+import { LoginState } from '@/states/stateLogin';
+import { useRecoilState } from 'recoil';
+import { login } from '@/lib/api';
+import { LoginBody } from '@/lib/types';
 
 const Login = () => {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const setUserState = useSetRecoilState(UserState);
+  const [loginError, setLoginError] = useState('');
   const [isLoggedIn, setIsLoggedIn] = useRecoilState(LoginState);
   const navigate = useNavigate();
+
+  const saveTokenToLocalstorage = (token: string) => {
+    localStorage.setItem('authToken', token);
+  };
+
+  useEffect(() => {
+    isLoggedIn && navigate('/');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const {
     register,
     handleSubmit,
     setError,
     formState: { errors },
-  } = useForm<FormData>();
+  } = useForm<LoginBody>();
 
-  //로그인 된 상태로 /login 접속시 메인으로 강제 이동
-  useEffect(() => {
-    isLoggedIn && navigate('/');
-  }, []);
-
-  const onSubmit = async (data: FormData) => {
+  const onSubmit = async (data: LoginBody) => {
     const validationErrors = SignUpValidation(data);
-    setEmail(data.email);
-    setPassword(data.password);
 
     if (Object.keys(validationErrors).length > 0) {
       Object.entries(validationErrors).forEach(([field, message]) => {
         setError(field, { type: 'manual', message });
       });
     } else {
-      //API호출
-      console.log(data);
-      const result = await postLogin({
-        email,
-        password,
-      });
-      setIsLoggedIn(true);
-      setUserState(result);
-      navigate('/');
+      try {
+        const response = await login({ email: data.email, password: data.password });
+        if (response && response.data.success) {
+          setLoginError('');
+          const token = response.headers.authorization;
+          saveTokenToLocalstorage(token);
+          setIsLoggedIn(true);
+          navigate('/');
+        } else {
+          setLoginError('로그인에 실패하셨습니다.');
+          console.error('로그인 실패');
+        }
+      } catch (error) {
+        setLoginError('로그인에 실패하셨습니다.');
+        console.error('로그인 실패', error);
+      }
     }
   };
 
@@ -77,6 +80,12 @@ const Login = () => {
               <InfoBox>
                 <FiAlertCircle />
                 <span className="info-text">{errors.password.message}</span>
+              </InfoBox>
+            )}
+            {loginError && (
+              <InfoBox>
+                <FiAlertCircle />
+                <span className="info-text">{loginError}</span>
               </InfoBox>
             )}
           </InputContainer>

--- a/src/states/stateLogin.ts
+++ b/src/states/stateLogin.ts
@@ -1,0 +1,10 @@
+import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+const { persistAtom } = recoilPersist();
+
+export const LoginState = atom<boolean>({
+  key: 'LoginState',
+  default: false,
+  effects_UNSTABLE: [persistAtom],
+});

--- a/src/states/stateLogin.ts
+++ b/src/states/stateLogin.ts
@@ -6,5 +6,10 @@ const { persistAtom } = recoilPersist();
 export const LoginState = atom<boolean>({
   key: 'LoginState',
   default: false,
+});
+
+export const UserState = atom<string>({
+  key: 'UserState',
+  default: '',
   effects_UNSTABLE: [persistAtom],
 });

--- a/src/states/stateLogin.ts
+++ b/src/states/stateLogin.ts
@@ -6,6 +6,7 @@ const { persistAtom } = recoilPersist();
 export const LoginState = atom<boolean>({
   key: 'LoginState',
   default: false,
+  effects_UNSTABLE: [persistAtom],
 });
 
 export const UserState = atom<string>({


### PR DESCRIPTION
## PR 타입

- [x] 기능 추가
- [ ] 버그 수정
- [x] 코드 업데이트
- [ ] 사소한 수정

<br />

## PR 요약

### 로그인 API를 연결 후 jwt를 로컬에 저장합니다.
로그아웃 api도 연결합니다.

<br />

## 변경사항
### 1. 로그인 api 연결
로그인 api를 `async/await`를 통해 비동기로 호출 한 뒤 
응답값 header의 토큰을 localstorage에 저장한 후, api index에서 토큰값을 가져와 사용합니다.
> `res`값에 header도 포함되어있어야 하기 때문에 index의 `return` 값이 `res.data`에서 `res`로 변경되었습니다.

<br />

### 2. 로그인 상태 전역 관리, `recoil-persist` 라이브러리 설치
login에 성공하면 `recoil`을 통해 로그인 상태를 `boolean`값으로 확인 할 수 있습니다.
그리고 새로고침하면 초기화 되는 전역 상태를 유지하여 사용하기 위해 `recoil-persist` 라이브러리를 설치하였습니다.

<br />


## 코드 참고사항
다슬님이 작업중이신` SideBar.tsx`, `Calendar.tsx`에 수정사항이 있습니다.
1. `SidBar.tsx`
로그아웃 api 추가
```  const handleClickLogout = async () => {
    await logout();
    localStorage.removeItem('authToken');
    setIsLoggedIn(false);
    setUserState('');
    navigate('/login');
  };
```


<br />

2. `Calendar.tsx`
로그인 상태 확인 후 값이 false일시 Login 페이지로 강제 네비게이트
```  useEffect(() => {
    !isLoggedIn && navigate('/login');
    // eslint-disable-next-line react-hooks/exhaustive-deps
  }, []);
```

참고 부탁드립니다!
