### PR TITLE
:sparkles: Feat: UserData Recoil 연결 후 데이터 사용

### DIFF
--- a/src/components/MainHeader.tsx
+++ b/src/components/MainHeader.tsx
@@ -1,35 +1,18 @@
-import axios from 'axios';
-import { useState, useEffect } from 'react';
 import { hospitalDecode } from '@/utils/decode';
 import { MdOutlineLocalHospital } from 'react-icons/md';
 import styled from 'styled-components';
+import { useRecoilValue } from 'recoil';
+import { UserDataState } from '@/states/stateUserdata';
 
 const MainHeader = () => {
-  const [hospitalName, setHospitalName] = useState('병원명');
-
-  // 유저 개인 정보 (mypage) - 재직 병원 확인
-  const getUserHospital = () => {
-    axios
-      .get('/junehee/mypage.json')
-      .then(res => {
-        if (res.status === 200) {
-          console.log('재직중인 병원 코드 확인', res.data.item.hospital_id);
-          const hospitalNum = res.data.item.hospital_id;
-          setHospitalName(hospitalDecode[hospitalNum].hospital);
-        }
-      })
-      .catch(error => console.error('재직 병원 코드 확인 실패', error));
-  };
-
-  useEffect(() => {
-    getUserHospital();
-  }, []);
+  const UserData = useRecoilValue(UserDataState);
+  const hospitalNum = UserData.hospital_id;
 
   return (
     <Container>
       <HosPitalName>
         <MdOutlineLocalHospital />
-        <span className="hospital-name">{hospitalName}</span>
+        {hospitalNum && <span className="hospital-name">{hospitalDecode[hospitalNum].hospital}</span>}
       </HosPitalName>
     </Container>
   );

--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -8,10 +8,9 @@ import AnnualBtn from '@/components/Buttons/AnnualBtn';
 import DutyBtn from '@/components/Buttons/DutyBtn';
 import { dname, getLevel } from '@/utils/decode';
 import { logout, getMyPage2 } from '@/lib/api';
-import { UserData } from '@/lib/types';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import { LoginState, UserState } from '@/states/stateLogin';
-import { UserIdState, HospitalIdState } from '@/states/stateUserId';
+import { UserDataState } from '@/states/stateUserdata';
 
 interface MenuItemProps {
   to: string;
@@ -27,36 +26,12 @@ interface ProgressProps {
   $percent: number;
 }
 
-const initialUserData: UserData = {
-  id: 0,
-  emp_no: 0,
-  name: '',
-  email: '',
-  phone: '',
-  hospital_id: 0,
-  dept_id: 0,
-  level: '',
-  auth: '',
-  status: '',
-  annual: 0,
-  duty: 0,
-  profile_image_url: '',
-  hiredate: '',
-  created_at: '',
-  updated_at: '',
-};
-
 const SideBar = () => {
-  const [User, setUser] = useState<UserData>(initialUserData);
+  const [User, setUser] = useRecoilState(UserDataState);
   const [isSubMenuOpen, setIsSubMenuOpen] = useState(false);
   const [isMyPageActive, setIsMyPageActive] = useState('false');
   const setIsLoggedIn = useSetRecoilState(LoginState);
   const setUserState = useSetRecoilState(UserState);
-
-  ///리코일
-  const setUserId = useSetRecoilState(UserIdState);
-  const setHospitalId = useSetRecoilState(HospitalIdState);
-  ///
 
   const navigate = useNavigate();
 
@@ -64,9 +39,8 @@ const SideBar = () => {
     (async () => {
       const data = await getMyPage2();
       setUser(data.item);
-      setUserId(data.item.id);
-      setHospitalId(data.item.hospital_id);
     })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   //그래프 퍼센트 계산

--- a/src/states/stateUserdata.ts
+++ b/src/states/stateUserdata.ts
@@ -1,0 +1,24 @@
+import { UserData } from '@/lib/types';
+import { atom } from 'recoil';
+
+export const UserDataState = atom<UserData>({
+  key: 'userData',
+  default: {
+    id: 0,
+    emp_no: 0,
+    name: '',
+    email: '',
+    phone: '',
+    hospital_id: 0,
+    dept_id: 0,
+    level: '',
+    auth: '',
+    status: '',
+    annual: 0,
+    duty: 0,
+    profile_image_url: '',
+    hiredate: '',
+    created_at: '',
+    updated_at: '',
+  },
+});


### PR DESCRIPTION
## PR 타입

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 업데이트
- [ ] 사소한 수정

<br />

## PR 요약
userdata를 불러와서 recoil state에 저장해서, 전역으로 관리합니다.

<br />

## 변경사항
sidebar, header에 recoil 값을 연결합니다.

<br />

## 코드 참고사항
