### PR TITLE
:sparkles: Feat: 날짜별 휴가 인원, 당직 인원 조회 모달 API 적용

### DIFF
--- a/src/components/Calendar/CalendarBody.tsx
+++ b/src/components/Calendar/CalendarBody.tsx
@@ -36,7 +36,6 @@ const CalendarBody = ({
     };
 
     openModal(modalData);
-    console.log('당직클릭', date.format('YYYY-MM-DD'));
   };
 
   const handleClickAnnual = (date: dayjs.Dayjs) => {
@@ -49,7 +48,6 @@ const CalendarBody = ({
     };
 
     openModal(modalData);
-    console.log('휴가클릭', date.format('YYYY-MM-DD'));
   };
 
   //달력 7일 6주 고정

--- a/src/components/Modals/CalAnnualModal.tsx
+++ b/src/components/Modals/CalAnnualModal.tsx
@@ -1,9 +1,22 @@
+import { useEffect, useState } from 'react';
+import { getAnnual } from '@/lib/api';
 import { styled } from 'styled-components';
+import { getLevel, getPhone } from '@/utils/decode';
+import { AnnualData } from '@/lib/types';
 
-export const CalAnnualModal = ({ date }) => {
+export const CalAnnualModal = ({ date }: { date: string }) => {
+  const [annual, setAnnual] = useState<AnnualData[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      const data = await getAnnual(date);
+      setAnnual(data.item);
+    })();
+  }, []);
+
   return (
     <Container>
-      <DateWrap> {date}</DateWrap>
+      <DateWrap>{date}</DateWrap>
       <TableContainer>
         <DataWrap>
           <div>No.</div>
@@ -12,13 +25,15 @@ export const CalAnnualModal = ({ date }) => {
           <div>직급</div>
           <div>연락처</div>
         </DataWrap>
-        <DataWrap>
-          <div>1</div>
-          <div>나영석</div>
-          <div>소아과</div>
-          <div>인턴</div>
-          <div>010-92982-1828</div>
-        </DataWrap>
+        {annual.map((item, index) => (
+          <DataWrap key={index}>
+            <div>{index + 1}</div>
+            <div>{item.username}</div>
+            <div>{item.deptName}</div>
+            <div>{getLevel(item.level)}</div>
+            <div>{getPhone(item.phone)}</div>
+          </DataWrap>
+        ))}
       </TableContainer>
     </Container>
   );

--- a/src/components/Modals/CalDutyModal.tsx
+++ b/src/components/Modals/CalDutyModal.tsx
@@ -1,27 +1,53 @@
+import { useEffect, useState } from 'react';
+import { getDuty } from '@/lib/api';
 import { styled } from 'styled-components';
+import { getLevel, getPhone } from '@/utils/decode';
+import { DutyData } from '@/lib/types';
 
-export const CalDutylModal = ({ date }) => {
+interface ProfileProps {
+  $imgurl: null | string;
+}
+
+const DutyDataInitial = {
+  deptName: '',
+  email: '',
+  id: 0,
+  level: '',
+  phone: '',
+  profileImageUrl: '',
+  userId: 0,
+  username: '',
+};
+
+export const CalDutylModal = ({ date }: { date: string }) => {
+  const [duty, setDuty] = useState<DutyData>(DutyDataInitial);
+
+  useEffect(() => {
+    (async () => {
+      const data = await getDuty(date);
+      setDuty(data.item);
+    })();
+  }, []);
+
   return (
     <Container>
-      <DateWrap> {date}</DateWrap>
+      <DateWrap>{date}</DateWrap>
       <UserWrap>
-        <UserImg />
+        {duty.profileImageUrl === null ? <UserImg $imgurl="/user.png" /> : <UserImg $imgurl={duty.profileImageUrl} />}
         <UserInfo>
           <NameCard>
-            <div className="name">김땡땡</div>
-            <div className="part">신경외과 레지던트</div>
+            <div className="name">{duty.username}</div>
+            <div className="part">
+              {duty.deptName} {getLevel(duty.level)}
+            </div>
           </NameCard>
           <DataCard>
-            <div className="dataTitle">사번</div>
-            <div className="dataText">1234123</div>
-          </DataCard>
-          <DataCard>
             <div className="dataTitle">전화번호</div>
-            <div className="dataText">010-9191-1919</div>
+            <div className="dataText">{getPhone(duty.phone)}</div>
           </DataCard>
           <DataCard>
             <div className="dataTitle">이메일</div>
-            <div className="dataText">eefef@edfef.com</div>
+            <div className="dataText">{duty.email}</div>
           </DataCard>
         </UserInfo>
       </UserWrap>
@@ -49,10 +75,10 @@ const UserWrap = styled.div`
   align-items: center;
   justify-content: center;
 `;
-const UserImg = styled.div`
+const UserImg = styled.div<ProfileProps>`
   width: 140px;
   height: 140px;
-  background-image: url(/user.png);
+  background-image: url(${props => props.$imgurl});
   background-position: center;
   background-size: contain;
   background-repeat: no-repeat;

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -119,7 +119,11 @@ export const getSchedule = async () => {
 // 날짜별 휴가 인원 조회
 export const getAnnual = async (date: string) => {
   try {
-    const res = await authInstance.get(`/schedule/date?chooseDate=${date}&category=ANNUAL`);
+    const res = await instance.get(`/schedule/date?chooseDate=${date}&category=ANNUAL`, {
+      headers: {
+        Authorization: `${localStorage.getItem('authToken')}`,
+      },
+    });
     return res.data;
   } catch (error) {
     console.log('휴가 인원 조회 실패', error);
@@ -129,7 +133,11 @@ export const getAnnual = async (date: string) => {
 // 날짜별 당직 인원 조회
 export const getDuty = async (date: string) => {
   try {
-    const res = await authInstance.get(`/schedule/date?chooseDate=${date}&category=DUTY`);
+    const res = await instance.get(`/schedule/date?chooseDate=${date}&category=DUTY`, {
+      headers: {
+        Authorization: `${localStorage.getItem('authToken')}`,
+      },
+    });
     return res.data;
   } catch (error) {
     console.log('당직 인원 조회 실패', error);

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -86,3 +86,24 @@ export interface Schedule {
   name: string;
   startDate: string;
 }
+
+//날짜별 휴가 조회
+export interface AnnualData {
+  deptName: string;
+  id: number;
+  level: string;
+  phone: string;
+  username: string;
+}
+
+//날짜별 당직 조회
+export interface DutyData {
+  deptName: string;
+  email: string;
+  id: number;
+  level: string;
+  phone: string;
+  profileImageUrl: string;
+  userId: number;
+  username: string;
+}

--- a/src/utils/decode.ts
+++ b/src/utils/decode.ts
@@ -115,3 +115,9 @@ export const dname: Dname = {
   32: '핵의학과',
   33: '가정의학과',
 };
+
+export const getPhone = (phone: string) => {
+  const part = phone.match(/^(\d{3})(\d{4})(\d{0,4})$/);
+  if (part === null) return phone;
+  return `${part[1]}-${part[2]}-${part[3]}`;
+};


### PR DESCRIPTION
## PR 타입

- [x] 기능 추가
- [ ] 버그 수정
- [x] 코드 업데이트
- [x] 사소한 수정

<br />

## PR 요약

캘린더에서 날짜별 휴가 또는 당직 정보 클릭 시 나오는 
날짜별 휴가 인원, 당직 인원 조회 모달 api 적용 

<br />

## 변경사항

타입 추가 / types
전화번호 '-'포함 출력을 위한 함수 추가 / decode 
캘린더에서 클릭시 나오는 콘솔 출력 삭제 
로그인 시 바로 모달 호출안되는 문제 확인 getAnnual,getDuty  api 호출 헤더 변경 

<br />


