### PR TITLE
:bug: Fix: 캘린더 데이터없는 날짜에는 휴가,당직 출력 컴포넌트 나오지 않게 수정

### DIFF
--- a/src/components/Calendar/CalendarBody.tsx
+++ b/src/components/Calendar/CalendarBody.tsx
@@ -121,44 +121,46 @@ const CalendarBody = ({
       return (
         <div key={index} className={className()}>
           <span className="calendar-date">{dateObj.format('D')}</span>
-          {dutyactive && !annualactive ? (
-            <Duty onClick={() => handleClickDuty(dateObj)}>
-              <span className="duty-name">{arrDuty.length > 0 ? '• ' + arrDuty[0] : ''}</span>
-              <span>{arrDuty.length > 0 ? getLevel(arrDuty[1]) : ''}</span>
-            </Duty>
-          ) : (
-            ''
-          )}
-          {annualactive && !dutyactive ? (
-            <Annual onClick={() => handleClickAnnual(dateObj)}>
-              {arrAnnual.length > 0 ? '• 휴가' + arrAnnual.length + '명' : ''}
-            </Annual>
-          ) : (
-            ''
-          )}
+          {dutyactive && !annualactive
+            ? arrDuty.length > 0 && (
+                <Duty onClick={() => handleClickDuty(dateObj)}>
+                  <span className="duty-name">• {arrDuty[0]}</span>
+                  <span>{getLevel(arrDuty[1])}</span>
+                </Duty>
+              )
+            : ''}
+          {annualactive && !dutyactive
+            ? arrAnnual.length > 0 && (
+                <Annual onClick={() => handleClickAnnual(dateObj)}>• 휴가{arrAnnual.length}명</Annual>
+              )
+            : ''}
 
           {!annualactive && !dutyactive ? (
             <>
-              <Duty onClick={() => handleClickDuty(dateObj)}>
-                <span className="duty-name">{arrDuty.length > 0 ? '• ' + arrDuty[0] : ''}</span>
-                <span>{arrDuty.length > 0 ? getLevel(arrDuty[1]) : ''}</span>
-              </Duty>
-              <Annual onClick={() => handleClickAnnual(dateObj)}>
-                {arrAnnual.length > 0 ? '• 휴가' + arrAnnual.length + '명' : ''}
-              </Annual>
+              {arrDuty.length > 0 && (
+                <Duty onClick={() => handleClickDuty(dateObj)}>
+                  <span className="duty-name">• {arrDuty[0]}</span>
+                  <span>{getLevel(arrDuty[1])}</span>
+                </Duty>
+              )}
+              {arrAnnual.length > 0 && (
+                <Annual onClick={() => handleClickAnnual(dateObj)}>• 휴가{arrAnnual.length}명</Annual>
+              )}
             </>
           ) : (
             ''
           )}
           {annualactive && dutyactive ? (
             <>
-              <Duty onClick={() => handleClickDuty(dateObj)}>
-                <span className="duty-name">{arrDuty.length > 0 ? '• ' + arrDuty[0] : ''}</span>
-                <span>{arrDuty.length > 0 ? getLevel(arrDuty[1]) : ''}</span>
-              </Duty>
-              <Annual onClick={() => handleClickAnnual(dateObj)}>
-                {arrAnnual.length > 0 ? '• 휴가' + arrAnnual.length + '명' : ''}
-              </Annual>
+              {arrDuty.length > 0 && (
+                <Duty onClick={() => handleClickDuty(dateObj)}>
+                  <span className="duty-name">• {arrDuty[0]}</span>
+                  <span>{getLevel(arrDuty[1])}</span>
+                </Duty>
+              )}
+              {arrAnnual.length > 0 && (
+                <Annual onClick={() => handleClickAnnual(dateObj)}>• 휴가{arrAnnual.length}명</Annual>
+              )}
             </>
           ) : (
             ''


### PR DESCRIPTION
## PR 타입

- [ ] 기능 추가
- [x] 버그 수정
- [x] 코드 업데이트
- [ ] 사소한 수정

<br />

## PR 요약

캘린더 데이터없는 날짜에는 휴가,당직 출력 컴포넌트 나오지 않게 수정

<br />

## 변경사항

캘린더에서 데이터가 없는 날짜에도 휴가,당직 출력 컴포넌트가 존재하는 것을 확인, 
데이터가 없는데 클릭이 가능해 데이터 없는 모달 출력 & 호출 에러 발생 하는것 발견 
데이터가 없는 날짜에는 출력 컴포넌트가 나오지 않게 수정했습니다. 

<br />

