### PR TITLE
🔨  Refactor: 로그인/회원가입 Error 레이아웃 수정

### DIFF
--- a/src/components/Modals/RequestModal.tsx
+++ b/src/components/Modals/RequestModal.tsx
@@ -45,6 +45,7 @@ export const RequestModal = ({ type }: { type: string }) => {
       }
     }
     if (type === 'duty') {
+      console.log(data.startDate, data.endDate);
       try {
         const res = await getDuty(data.startDate.toString());
         const scheduleIds = res.item.id;

--- a/src/lib/Validation/index.ts
+++ b/src/lib/Validation/index.ts
@@ -28,10 +28,18 @@ const nameValidation = {
 
 const hospitalValidation = {
   required: '재직 병원은 필수 입력입니다.',
+  pattern: {
+    value: /^병원/,
+    message: '재직 병원은 필수 입력입니다.',
+  },
 };
 
 const deptValidation = {
   required: '근무 파트는 필수 입력입니다.',
+  pattern: {
+    value: /과/,
+    message: '재직 병원은 필수 입력입니다.',
+  },
 };
 
 const phoneValidation = {

--- a/src/lib/Validation/index.ts
+++ b/src/lib/Validation/index.ts
@@ -29,7 +29,7 @@ const nameValidation = {
 const hospitalValidation = {
   required: '재직 병원은 필수 입력입니다.',
   pattern: {
-    value: /^병원/,
+    value: /병원/,
     message: '재직 병원은 필수 입력입니다.',
   },
 };

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -70,30 +70,36 @@ const Login = () => {
         <h1>어서오세요!</h1>
         <FormWrap onSubmit={handleSubmit(onSubmit)} name="loginForm">
           <InputContainer>
-            <div className="inputTitle">email</div>
+            <ErrorBox>
+              <div className="inputTitle">email</div>
+              {errors.email && (
+                <InfoBox>
+                  <FiAlertCircle />
+                  <span className="info-text">{errors.email.message}</span>
+                </InfoBox>
+              )}
+            </ErrorBox>
             <input type="email" placeholder="이메일을 입력해주세요." {...register('email')} />
-            {errors.email && (
-              <InfoBox>
-                <FiAlertCircle />
-                <span className="info-text">{errors.email.message}</span>
-              </InfoBox>
-            )}
           </InputContainer>
           <InputContainer>
-            <div className="inputTitle">password</div>
+            <ErrorBox>
+              <div className="inputTitle">password</div>
+              {errors.password && (
+                <InfoBox>
+                  <FiAlertCircle />
+                  <span className="info-text">{errors.password.message}</span>
+                </InfoBox>
+              )}
+            </ErrorBox>
             <input type="password" placeholder="비밀번호를 입력해주세요." {...register('password')} />
-            {errors.password && (
-              <InfoBox>
-                <FiAlertCircle />
-                <span className="info-text">{errors.password.message}</span>
-              </InfoBox>
-            )}
-            {loginError && (
-              <InfoBox>
-                <FiAlertCircle />
-                <span className="info-text">{loginError}</span>
-              </InfoBox>
-            )}
+            <RejectLogin>
+              {loginError && (
+                <InfoBox>
+                  <FiAlertCircle />
+                  <span className="info-text">{loginError}</span>
+                </InfoBox>
+              )}
+            </RejectLogin>
           </InputContainer>
           <InputContainer>
             <Btn content={'로그인'} />
@@ -186,28 +192,41 @@ const InputContainer = styled.div`
   .inputTitle {
     font-size: 14px;
     font-family: 'ABeeZee', sans-serif;
-    margin-bottom: 8px;
   }
   button {
-    margin-top: 62px;
+    margin-top: 10px;
   }
   &:first-child {
     margin-bottom: 16px;
   }
 `;
-
+const ErrorBox = styled.div`
+  display: flex;
+  align-items: center;
+  width: 320px;
+  height: 20px;
+  margin-bottom: 4px;
+`;
 const InfoBox = styled.div`
-  margin-top: 8px;
   display: flex;
   align-items: center;
   color: red;
   font-size: 12px;
+  margin-left: 10px;
   .info-text {
-    margin-left: 8px;
+    margin-left: 4px;
   }
 `;
 const SignUpLink = styled.div`
   font-size: 14px;
+`;
+const RejectLogin = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 320px;
+  height: 20px;
+  margin: 20px 0 10px;
 `;
 
 export default Login;

--- a/src/pages/RequestList.tsx
+++ b/src/pages/RequestList.tsx
@@ -82,7 +82,7 @@ const RequestList = () => {
     return sortedKeys.map(key => (
       <DataWrap key={requestLists[key].id}>
         <div className="box1">{key + 1}</div>
-        <div className="box2">{getCategory(requestLists[key].category)}</div>
+        <div className="box2">{getCategory(requestLists[key].category, requestLists[key].evaluation)}</div>
         <div className="box3">{requestLists[key].createdAt.slice(0, 10)}</div>
         <div className="box4">
           {requestLists[key].startDate === requestLists[key].endDate

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -140,23 +140,27 @@ const SignUp = () => {
             <span>가입 정보</span>
 
             <Label>
-              Email
-              {errors?.email && (
-                <InfoBox>
-                  <FiAlertCircle />
-                  <div className="info-text">{errors.email.message}</div>
-                </InfoBox>
-              )}
+              <ErrorBox>
+                Email
+                {errors?.email && (
+                  <InfoBox>
+                    <FiAlertCircle />
+                    <div className="info-text">{errors.email.message}</div>
+                  </InfoBox>
+                )}
+              </ErrorBox>
               <Input type="email" placeholder="kim@doctor.kr" {...register('email', emailValidation)} />
             </Label>
             <Label>
-              Password
-              {errors?.password && (
-                <InfoBox>
-                  <FiAlertCircle />
-                  <div className="info-text">{errors.password.message}</div>
-                </InfoBox>
-              )}
+              <ErrorBox>
+                Password
+                {errors?.password && (
+                  <InfoBox>
+                    <FiAlertCircle />
+                    <div className="info-text">{errors.password.message}</div>
+                  </InfoBox>
+                )}
+              </ErrorBox>
               <Input
                 type="password"
                 maxLength={20}
@@ -165,13 +169,15 @@ const SignUp = () => {
               />
             </Label>
             <Label>
-              Password Check
-              {errors?.pwCheck && (
-                <InfoBox>
-                  <FiAlertCircle />
-                  <div className="info-text">{errors.pwCheck.message}</div>
-                </InfoBox>
-              )}
+              <ErrorBox>
+                Password Check
+                {errors?.pwCheck && (
+                  <InfoBox>
+                    <FiAlertCircle />
+                    <div className="info-text">{errors.pwCheck.message}</div>
+                  </InfoBox>
+                )}
+              </ErrorBox>
               <Input
                 type="password"
                 placeholder="비밀번호를 다시 입력해 주세요."
@@ -189,23 +195,27 @@ const SignUp = () => {
           <InfoWrapper>
             <span>유저 정보</span>
             <Label>
-              name
-              {errors?.name && (
-                <InfoBox>
-                  <FiAlertCircle />
-                  <div className="info-text">{errors.name.message}</div>
-                </InfoBox>
-              )}
+              <ErrorBox>
+                name
+                {errors?.name && (
+                  <InfoBox>
+                    <FiAlertCircle />
+                    <div className="info-text">{errors.name.message}</div>
+                  </InfoBox>
+                )}
+              </ErrorBox>
               <Input type="text" placeholder="김의사" maxLength={10} {...register('name', nameValidation)} />
             </Label>
             <Label>
-              Hospital
-              {errors?.hospital && (
-                <InfoBox>
-                  <FiAlertCircle />
-                  {errors.hospital.message}
-                </InfoBox>
-              )}
+              <ErrorBox>
+                Hospital
+                {errors?.hospital && (
+                  <InfoBox>
+                    <FiAlertCircle />
+                    <div className="info-text">{errors.hospital.message}</div>
+                  </InfoBox>
+                )}
+              </ErrorBox>
               <select
                 required
                 defaultValue="default"
@@ -223,13 +233,15 @@ const SignUp = () => {
               </select>
             </Label>
             <Label>
-              Part
-              {errors?.dept && (
-                <InfoBox>
-                  <FiAlertCircle />
-                  {errors.dept.message}
-                </InfoBox>
-              )}
+              <ErrorBox>
+                Part
+                {errors?.dept && (
+                  <InfoBox>
+                    <FiAlertCircle />
+                    <div className="info-text">{errors.dept.message}</div>
+                  </InfoBox>
+                )}
+              </ErrorBox>
               <select required defaultValue="default" {...register('dept', deptValidation)}>
                 <option value="default" disabled hidden>
                   근무 파트를 선택해 주세요.
@@ -246,13 +258,15 @@ const SignUp = () => {
               </select>
             </Label>
             <Label>
-              Phone Number
-              {errors?.phone && (
-                <InfoBox>
-                  <FiAlertCircle />
-                  <div className="info-text">{errors.phone.message}</div>
-                </InfoBox>
-              )}
+              <ErrorBox>
+                Phone Number
+                {errors?.phone && (
+                  <InfoBox>
+                    <FiAlertCircle />
+                    <div className="info-text">{errors.phone.message}</div>
+                  </InfoBox>
+                )}
+              </ErrorBox>
               <Input
                 type="text"
                 placeholder="하이픈(-) 없이 입력하세요."
@@ -386,6 +400,13 @@ const Input = styled.input`
   font-family: 'Pretendard', sans-serif;
 `;
 
+const ErrorBox = styled.div`
+  display: flex;
+  align-items: center;
+  width: 320px;
+  height: 20px;
+`;
+
 const Option = styled.option`
   &.default {
     color: red;
@@ -411,8 +432,9 @@ const InfoBox = styled.div`
   align-items: center;
   color: red;
   font-size: 12px;
+  margin-left: 10px;
   .info-text {
     font-family: 'Pretendard', 'sans-serif';
-    margin-left: 8px;
+    margin-left: 4px;
   }
 `;

--- a/src/utils/decode.ts
+++ b/src/utils/decode.ts
@@ -120,18 +120,20 @@ export const getPhone = (phone: string) => {
   return `${part[1]}-${part[2]}-${part[3]}`;
 };
 
-export const getCategory = (category: string) => {
-  if (category === 'ANNUAL') {
-    return '휴가 신청';
-  } else {
+export const getCategory = (category: string, evaluation: string) => {
+  if (category === 'DUTY' && evaluation !== 'APPROVED') {
     return '당직 변경 신청';
+  } else if (category === 'DUTY' && evaluation === 'APPROVED') {
+    return '당직';
+  } else {
+    return '휴가 신청';
   }
 };
 
 export const getEvaluation = (eveluation: string) => {
   if (eveluation === 'STANDBY') {
     return '대기';
-  } else if (eveluation === 'APPROVED') {
+  } else if (eveluation === 'APPROVED' || eveluation === 'COMPLETED') {
     return '승인';
   } else if (eveluation === 'REJECTED') {
     return '반려';


### PR DESCRIPTION
## PR 타입

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 코드 업데이트
- [x] 사소한 수정

<br />

## PR 요약

로그인, 회원가입 페이지의 Validation Error Message 레이아웃을 수정합니다.

<br />

## 변경사항

기존 아래에 노출되던 레이아웃을 <lable>과 동일 선상에 두어
에러 메세지 노출 시에도 레이아웃 뒤틀림 없이 UI 지속 가능
