### PR TITLE
✨ Feat: 전역 사용 가능한 Alert 구현 및 적용

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -1,0 +1,89 @@
+import { useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
+import { alertState } from '@/states/stateAlert';
+import { IoAlertCircleOutline } from 'react-icons/Io5';
+import Btn from '@/components/Buttons/Btn';
+import styled from 'styled-components';
+
+const Alert = () => {
+  const { isOpen, content } = useRecoilValue(alertState);
+  const [, setAlert] = useRecoilState(alertState);
+
+  const onClickAlertClose = () => {
+    setAlert({
+      isOpen: false,
+      content: '',
+      type: 'error',
+    });
+  };
+
+  return (
+    isOpen && (
+      <Background onClick={onClickAlertClose}>
+        <Container>
+          <IconWrap>
+            <IoAlertCircleOutline />
+          </IconWrap>
+          <Contents>{content}</Contents>
+          <ButtonWrap onClick={onClickAlertClose}>
+            <Btn content="확인" />
+          </ButtonWrap>
+        </Container>
+      </Background>
+    )
+  );
+};
+
+export default Alert;
+
+const Background = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0.4);
+  z-index: 9;
+`;
+
+const Container = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  width: 400px;
+  height: 250px;
+  padding: 46px 46px 56px 46px;
+  border-radius: 8px;
+  background-color: ${props => props.theme.white};
+  z-index: 10;
+`;
+
+const IconWrap = styled.div`
+  display: flex;
+  width: 50px;
+  height: 50px;
+
+  svg {
+    width: 100%;
+    height: 100%;
+    color: ${props => props.theme.red};
+  }
+`;
+
+const Contents = styled.div`
+  display: flex;
+  font-size: 14px;
+  white-space: pre-wrap;
+`;
+
+const ButtonWrap = styled.div`
+  position: absolute;
+  bottom: 0;
+  display: flex;
+  margin-bottom: 56px;
+`;

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -78,6 +78,8 @@ const IconWrap = styled.div`
 const Contents = styled.div`
   display: flex;
   font-size: 14px;
+  text-align: center;
+  line-height: 1.5;
   white-space: pre-wrap;
 `;
 

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -1,5 +1,4 @@
-import { useRecoilValue } from 'recoil';
-import { useRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { alertState } from '@/states/stateAlert';
 import { IoAlertCircleOutline } from 'react-icons/Io5';
 import Btn from '@/components/Buttons/Btn';
@@ -7,7 +6,7 @@ import styled from 'styled-components';
 
 const Alert = () => {
   const { isOpen, content } = useRecoilValue(alertState);
-  const [, setAlert] = useRecoilState(alertState);
+  const setAlert = useSetRecoilState(alertState);
 
   const onClickAlertClose = () => {
     setAlert({

--- a/src/components/Modals/CalAnnualModal.tsx
+++ b/src/components/Modals/CalAnnualModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { getAnnual } from '@/lib/api';
 import { getLevel } from '@/utils/decode';
 import { getPhone } from '@/utils/getPhone';
@@ -11,7 +11,7 @@ import styled from 'styled-components';
 
 export const CalAnnualModal = ({ date }: { date: string }) => {
   const [annual, setAnnual] = useState<AnnualData[]>([]);
-  const [, setAlert] = useRecoilState<AlertState>(alertState);
+  const setAlert = useSetRecoilState<AlertState>(alertState);
 
   useEffect(() => {
     (async () => {

--- a/src/components/Modals/CalAnnualModal.tsx
+++ b/src/components/Modals/CalAnnualModal.tsx
@@ -1,23 +1,38 @@
 import { useEffect, useState } from 'react';
+import { useRecoilState } from 'recoil';
 import { getAnnual } from '@/lib/api';
-import { styled } from 'styled-components';
 import { getLevel } from '@/utils/decode';
 import { getPhone } from '@/utils/getPhone';
-import { AnnualData } from '@/lib/types';
+import { AnnualData, AlertState } from '@/lib/types';
 import { MODAL_TEXTS } from '@/constants/modals';
+import { alertState } from '@/states/stateAlert';
+import Alert from '@/components/Alert';
+import styled from 'styled-components';
 
 export const CalAnnualModal = ({ date }: { date: string }) => {
   const [annual, setAnnual] = useState<AnnualData[]>([]);
+  const [, setAlert] = useRecoilState<AlertState>(alertState);
 
   useEffect(() => {
     (async () => {
-      const data = await getAnnual(date);
-      setAnnual(data.item);
+      try {
+        const res = await getAnnual(date);
+        if (res.success) {
+          setAnnual(res.item);
+        }
+      } catch (error) {
+        setAlert({
+          isOpen: true,
+          content: `휴가 인원 조회 실패\n${error}`,
+          type: 'error',
+        });
+      }
     })();
   }, []);
 
   return (
     <Container>
+      <Alert />
       <DateWrap>{date}</DateWrap>
       <TableContainer>
         <DataWrap>

--- a/src/components/Modals/CalDutyModal.tsx
+++ b/src/components/Modals/CalDutyModal.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react';
 import { getDuty } from '@/lib/api';
-import { styled } from 'styled-components';
 import { getLevel } from '@/utils/decode';
 import { getPhone } from '@/utils/getPhone';
-import { DutyData, ProfileProps } from '@/lib/types';
+import { AlertState, DutyData, ProfileProps } from '@/lib/types';
 import { MODAL_TEXTS } from '@/constants/modals';
+import { useRecoilState } from 'recoil';
+import { alertState } from '@/states/stateAlert';
+import styled from 'styled-components';
 
 const DutyDataInitial = {
   deptName: '',
@@ -17,15 +19,26 @@ const DutyDataInitial = {
   username: '',
 };
 
-const baseUrl = 'http://fastcampus-mini-project-env.eba-khrscmx7.ap-northeast-2.elasticbeanstalk.com';
-
 export const CalDutylModal = ({ date }: { date: string }) => {
+  const { VITE_BASE_URL } = import.meta.env;
+
   const [duty, setDuty] = useState<DutyData>(DutyDataInitial);
+  const [, setAlert] = useRecoilState<AlertState>(alertState);
 
   useEffect(() => {
     (async () => {
-      const data = await getDuty(date);
-      setDuty(data.item);
+      try {
+        const res = await getDuty(date);
+        if (res.success) {
+          setDuty(res.item);
+        }
+      } catch (error) {
+        setAlert({
+          isOpen: true,
+          content: `당직 인원 조회 실패\n${error}`,
+          type: 'error',
+        });
+      }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -37,7 +50,7 @@ export const CalDutylModal = ({ date }: { date: string }) => {
         {duty.profileImageUrl === null ? (
           <UserImg $imgurl="/user.png" />
         ) : (
-          <UserImg $imgurl={baseUrl + duty.profileImageUrl} />
+          <UserImg $imgurl={VITE_BASE_URL + duty.profileImageUrl} />
         )}
         <UserInfo>
           <NameCard>

--- a/src/components/Modals/CalDutyModal.tsx
+++ b/src/components/Modals/CalDutyModal.tsx
@@ -4,7 +4,7 @@ import { getLevel } from '@/utils/decode';
 import { getPhone } from '@/utils/getPhone';
 import { AlertState, DutyData, ProfileProps } from '@/lib/types';
 import { MODAL_TEXTS } from '@/constants/modals';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { alertState } from '@/states/stateAlert';
 import styled from 'styled-components';
 
@@ -23,7 +23,7 @@ export const CalDutylModal = ({ date }: { date: string }) => {
   const { VITE_BASE_URL } = import.meta.env;
 
   const [duty, setDuty] = useState<DutyData>(DutyDataInitial);
-  const [, setAlert] = useRecoilState<AlertState>(alertState);
+  const setAlert = useSetRecoilState<AlertState>(alertState);
 
   useEffect(() => {
     (async () => {

--- a/src/components/Modals/RequestModal.tsx
+++ b/src/components/Modals/RequestModal.tsx
@@ -28,13 +28,15 @@ export const RequestModal = ({ type }: { type: string }) => {
 
     if (type === 'annual') {
       try {
-        await createAnnual({
+        const res = await createAnnual({
           startDate: data.startDate,
           endDate: data.endDate,
           reason: data.reason,
         });
-        closeModal();
-        openModal(modalData);
+        if (res.success) {
+          closeModal();
+          openModal(modalData);
+        }
       } catch (error) {
         setErrorMessage(MODAL_TEXTS.errors.failApplyAnnual);
       }
@@ -64,7 +66,7 @@ export const RequestModal = ({ type }: { type: string }) => {
 
     if (type === 'annualEdit') {
       try {
-        await editAnnual(
+        const res = await editAnnual(
           {
             startDate: data.startDate,
             endDate: data.endDate,
@@ -72,8 +74,10 @@ export const RequestModal = ({ type }: { type: string }) => {
           },
           scheduleId,
         );
-        closeModal();
-        openModal(modalData);
+        if (res.success) {
+          closeModal();
+          openModal(modalData);
+        }
       } catch (error) {
         setErrorMessage(MODAL_TEXTS.errors.failEditAnnual);
       }

--- a/src/components/Modals/checkModal.tsx
+++ b/src/components/Modals/checkModal.tsx
@@ -2,19 +2,34 @@ import { MODAL_TEXTS } from '@/constants/modals';
 import { useModal } from '@/hooks/useModal';
 import { cancelAnnual } from '@/lib/api';
 import { useNavigate } from 'react-router';
+import Alert from '@/components/Alert';
 import styled from 'styled-components';
+import { useRecoilState } from 'recoil';
+import { AlertState } from '@/lib/types';
+import { alertState } from '@/states/stateAlert';
 
 const CheckModal = ({ type }: { type: string | number }) => {
   const navigate = useNavigate();
   const { closeModal } = useModal();
+  const [, setAlert] = useRecoilState<AlertState>(alertState);
 
   const destination = `/${type}`;
 
   const handleOnClickYes = async () => {
     if (typeof type === 'number') {
-      await cancelAnnual(type, { id: type });
-      closeModal();
-      location.reload();
+      try {
+        const res = await cancelAnnual(type, { id: type });
+        if (res.success) {
+          closeModal();
+          location.reload();
+        }
+      } catch (error) {
+        setAlert({
+          isOpen: true,
+          content: `연차 신청 취소 실패\n${error}`,
+          type: 'error',
+        });
+      }
     } else {
       closeModal();
       navigate(destination);
@@ -24,6 +39,7 @@ const CheckModal = ({ type }: { type: string | number }) => {
 
   return (
     <Container>
+      <Alert />
       {typeof type === 'string' && <div>{MODAL_TEXTS.check}</div>}
       <BtnWrap>
         <AnswerBtn className="yseBtn" onClick={() => handleOnClickYes()}>

--- a/src/components/Modals/checkModal.tsx
+++ b/src/components/Modals/checkModal.tsx
@@ -4,14 +4,14 @@ import { cancelAnnual } from '@/lib/api';
 import { useNavigate } from 'react-router';
 import Alert from '@/components/Alert';
 import styled from 'styled-components';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { AlertState } from '@/lib/types';
 import { alertState } from '@/states/stateAlert';
 
 const CheckModal = ({ type }: { type: string | number }) => {
   const navigate = useNavigate();
   const { closeModal } = useModal();
-  const [, setAlert] = useRecoilState<AlertState>(alertState);
+  const setAlert = useSetRecoilState<AlertState>(alertState);
 
   const destination = `/${type}`;
 

--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -9,7 +9,7 @@ import DutyBtn from '@/components/Buttons/DutyBtn';
 import Alert from '@/components/Alert';
 import { getLevel, deptName } from '@/utils/decode';
 import { logout, getMyPage } from '@/lib/api';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import { UserDataState } from '@/states/stateUserdata';
 import { SIDE_BAR_TEXTS } from '@/constants/sideBar';
 import { MenuItemProps, SubMenuProps, ProgressProps, AlertState } from '@/lib/types';
@@ -17,7 +17,7 @@ import { alertState } from '@/states/stateAlert';
 
 const SideBar = () => {
   const [User, setUser] = useRecoilState(UserDataState);
-  const [, setAlert] = useRecoilState<AlertState>(alertState);
+  const setAlert = useSetRecoilState<AlertState>(alertState);
 
   const [isSubMenuOpen, setIsSubMenuOpen] = useState(false);
   const [isMyPageActive, setIsMyPageActive] = useState('false');

--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -6,15 +6,19 @@ import { BsFillPersonFill } from 'react-icons/bs';
 import { FaRegPaperPlane } from 'react-icons/fa';
 import AnnualBtn from '@/components/Buttons/AnnualBtn';
 import DutyBtn from '@/components/Buttons/DutyBtn';
+import Alert from '@/components/Alert';
 import { getLevel, deptName } from '@/utils/decode';
 import { logout, getMyPage } from '@/lib/api';
 import { useRecoilState } from 'recoil';
 import { UserDataState } from '@/states/stateUserdata';
 import { SIDE_BAR_TEXTS } from '@/constants/sideBar';
-import { MenuItemProps, SubMenuProps, ProgressProps } from '@/lib/types';
+import { MenuItemProps, SubMenuProps, ProgressProps, AlertState } from '@/lib/types';
+import { alertState } from '@/states/stateAlert';
 
 const SideBar = () => {
   const [User, setUser] = useRecoilState(UserDataState);
+  const [, setAlert] = useRecoilState<AlertState>(alertState);
+
   const [isSubMenuOpen, setIsSubMenuOpen] = useState(false);
   const [isMyPageActive, setIsMyPageActive] = useState('false');
 
@@ -22,10 +26,19 @@ const SideBar = () => {
 
   useEffect(() => {
     (async () => {
-      const data = await getMyPage();
-      setUser(data.item);
+      try {
+        const res = await getMyPage();
+        if (res.success) {
+          setUser(res.item);
+        }
+      } catch (error) {
+        setAlert({
+          isOpen: true,
+          content: `마이페이지 조회 실패\n${error}`,
+          type: 'error',
+        });
+      }
     })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   //그래프 퍼센트 계산
@@ -47,13 +60,24 @@ const SideBar = () => {
   };
 
   const handleClickLogout = async () => {
-    await logout();
-    localStorage.removeItem('authToken');
-    navigate('/login');
+    try {
+      const res = await logout();
+      if (res.success) {
+        localStorage.removeItem('authToken');
+        navigate('/login');
+      }
+    } catch (error) {
+      setAlert({
+        isOpen: true,
+        content: `로그아웃 실패\n${error}`,
+        type: 'error',
+      });
+    }
   };
 
   return (
     <Container>
+      <Alert />
       <NavLink to={'/'}>
         <Logo></Logo>
       </NavLink>

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -102,30 +102,22 @@ export const getDuty = async (date: string) => {
 
 // 요청 내역 확인
 export const getRequest = async (userId: number) => {
-  try {
-    const res = await instance.get(`/schedule/${userId}`, {
-      headers: {
-        Authorization: `${localStorage.getItem('authToken')}`,
-      },
-    });
-    return res.data;
-  } catch (error) {
-    return error;
-  }
+  const res = await instance.get(`/schedule/${userId}`, {
+    headers: {
+      Authorization: `${localStorage.getItem('authToken')}`,
+    },
+  });
+  return res.data;
 };
 
 // 연차 등록
 export const createAnnual = async (body: CreateAnnualBody) => {
-  try {
-    const res = await instance.post('/schedule/create/annual', body, {
-      headers: {
-        Authorization: `${localStorage.getItem('authToken')}`,
-      },
-    });
-    return res.data;
-  } catch (error) {
-    return error;
-  }
+  const res = await instance.post('/schedule/create/annual', body, {
+    headers: {
+      Authorization: `${localStorage.getItem('authToken')}`,
+    },
+  });
+  return res.data;
 };
 
 // 연차 내용 수정

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -24,116 +24,80 @@ const instance = axios.create({
 
 // 로그인
 export const login = async (body: LoginBody) => {
-  try {
-    const res = await instance.post('/user/login', body);
-    return res;
-  } catch (error) {
-    console.error('로그인 실패', error);
-  }
+  const res = await instance.post('/user/login', body);
+  return res;
 };
 
 // 로그아웃
 export const logout = async () => {
-  try {
-    const res = await instance.post('/user/logout');
-    return res.data;
-  } catch (error) {
-    console.error('로그아웃 실패');
-  }
+  const res = await instance.post('/user/logout');
+  return res.data;
 };
 
 // 회원가입
 export const signUp = async (body: SignUpBody) => {
-  try {
-    const res = await instance.post('/user/register', body);
-    return res.data;
-  } catch (error) {
-    console.error('회원가입 실패', error);
-  }
+  const res = await instance.post('/user/register', body);
+  return res.data;
 };
 
 // 마이페이지
 export const getMyPage = async () => {
-  try {
-    const res = await instance.get('/user/myPage', {
-      headers: {
-        Authorization: `${localStorage.getItem('authToken')}`,
-      },
-    });
-    return res.data;
-  } catch (error) {
-    console.error('마이페이지 조회 실패', error);
-  }
+  const res = await instance.get('/user/myPage', {
+    headers: {
+      Authorization: `${localStorage.getItem('authToken')}`,
+    },
+  });
+  return res.data;
 };
 
 // 마이페이지 수정
 export const editMyPage = async (body: EditMyPageBody) => {
-  try {
-    const res = await instance.post('/user/editUser', body, {
-      headers: {
-        Authorization: `${localStorage.getItem('authToken')}`,
-      },
-    });
-    return res.data;
-  } catch (error) {
-    console.error('마이페이지 수정 실패', error);
-  }
+  const res = await instance.post('/user/editUser', body, {
+    headers: {
+      Authorization: `${localStorage.getItem('authToken')}`,
+    },
+  });
+  return res.data;
 };
 
 // 비밀번호 변경
 export const editPassword = async (body: EditPasswordBody) => {
-  try {
-    const res = await instance.post('/user/updatePassword', body, {
-      headers: {
-        Authorization: `${localStorage.getItem('authToken')}`,
-      },
-    });
-    return res.data;
-  } catch (error) {
-    console.error('비밀번호 변경 실패', error);
-  }
+  const res = await instance.post('/user/updatePassword', body, {
+    headers: {
+      Authorization: `${localStorage.getItem('authToken')}`,
+    },
+  });
+  return res.data;
 };
 
 // 메인 캘린더 조회
 export const getSchedule = async () => {
-  try {
-    const res = await instance.get('/schedule/', {
-      headers: {
-        Authorization: `${localStorage.getItem('authToken')}`,
-      },
-    });
-    return res.data;
-  } catch (error) {
-    console.error('캘린더 조회 실패', error);
-  }
+  const res = await instance.get('/schedule/', {
+    headers: {
+      Authorization: `${localStorage.getItem('authToken')}`,
+    },
+  });
+  return res.data;
 };
 
 // 날짜별 휴가 인원 조회
 export const getAnnual = async (date: string) => {
-  try {
-    const res = await instance.get(`/schedule/date?chooseDate=${date}&category=ANNUAL`, {
-      headers: {
-        Authorization: `${localStorage.getItem('authToken')}`,
-      },
-    });
-    return res.data;
-  } catch (error) {
-    console.error('휴가 인원 조회 실패', error);
-  }
+  const res = await instance.get(`/schedule/date?chooseDate=${date}&category=ANNUAL`, {
+    headers: {
+      Authorization: `${localStorage.getItem('authToken')}`,
+    },
+  });
+  return res.data;
 };
 
 // 날짜별 당직 인원 조회
 export const getDuty = async (date: string) => {
-  try {
-    const res = await instance.get(`/schedule/date?chooseDate=${date}&category=DUTY`, {
-      headers: {
-        Authorization: `${localStorage.getItem('authToken')}`,
-      },
-    });
-    return res.data;
-  } catch (error) {
-    console.error('당직 인원 조회 실패', error);
-  }
+  const res = await instance.get(`/schedule/date?chooseDate=${date}&category=DUTY`, {
+    headers: {
+      Authorization: `${localStorage.getItem('authToken')}`,
+    },
+  });
+  return res.data;
 };
 
 // 요청 내역 확인
@@ -146,7 +110,7 @@ export const getRequest = async (userId: number) => {
     });
     return res.data;
   } catch (error) {
-    console.error('요청 내역 확인 실패', error);
+    return error;
   }
 };
 
@@ -160,83 +124,58 @@ export const createAnnual = async (body: CreateAnnualBody) => {
     });
     return res.data;
   } catch (error) {
-    console.error('연차 등록 요청 실패', error);
-    throw error;
+    return error;
   }
 };
 
 // 연차 내용 수정
 export const editAnnual = async (body: EditAnnualBody, scheduleId: number) => {
-  try {
-    const res = await instance.post(`/schedule/annual/${scheduleId}/update`, body, {
-      headers: {
-        Authorization: `${localStorage.getItem('authToken')}`,
-      },
-    });
-    return res.data;
-  } catch (error) {
-    console.error('연차 내용 수정 실패', error);
-  }
+  const res = await instance.post(`/schedule/annual/${scheduleId}/update`, body, {
+    headers: {
+      Authorization: `${localStorage.getItem('authToken')}`,
+    },
+  });
+  return res.data;
 };
 
+// 연차 신청 취소
 export const cancelAnnual = async (scheduleId: number, body: CancelAnnualBody) => {
-  try {
-    const res = await instance.post(`/schedule/annual/delete?id=${scheduleId}`, body, {
-      headers: {
-        Authorization: `${localStorage.getItem('authToken')}`,
-      },
-    });
-    return res.data;
-  } catch (error) {
-    console.error('연차 신청 취소 실패', error);
-  }
+  const res = await instance.post(`/schedule/annual/delete?id=${scheduleId}`, body, {
+    headers: {
+      Authorization: `${localStorage.getItem('authToken')}`,
+    },
+  });
+  return res.data;
 };
 
 // 당직 등록 (사용 여부 체크!)
 export const createDuty = async (body: CreateDutyBody) => {
-  try {
-    const res = await instance.post('/schedule/create/duty', body, {
-      headers: {
-        Authorization: `${localStorage.getItem('authToken')}`,
-      },
-    });
-    return res.data;
-  } catch (error) {
-    console.error('당직 등록 실패', error);
-  }
+  const res = await instance.post('/schedule/create/duty', body, {
+    headers: {
+      Authorization: `${localStorage.getItem('authToken')}`,
+    },
+  });
+  return res.data;
 };
 
 // 당직 내용 수정
 export const editDuty = async (body: EditDutyBody, scheduleId: number) => {
-  try {
-    const res = await instance.post(`/schedule/duty/${scheduleId}/update`, body, {
-      headers: {
-        Authorization: `${localStorage.getItem('authToken')}`,
-      },
-    });
-    return res.data;
-  } catch (error) {
-    console.error('당직 내용 수정 실패', error);
-    throw error;
-  }
+  const res = await instance.post(`/schedule/duty/${scheduleId}/update`, body, {
+    headers: {
+      Authorization: `${localStorage.getItem('authToken')}`,
+    },
+  });
+  return res.data;
 };
 
 // 병원 정보 리스트
 export const getHospitalList = async () => {
-  try {
-    const res = await instance.get('/hospital/list');
-    return res.data;
-  } catch (error) {
-    console.error('병원 정보 리스트 조회 실패', error);
-  }
+  const res = await instance.get('/hospital');
+  return res.data;
 };
 
 // 병원 과 리스트
 export const getDeptList = async (hospitalId: number) => {
-  try {
-    const res = await instance.get(`/dept/${hospitalId}/list`);
-    return res.data;
-  } catch (error) {
-    console.error('병원 과 리스트 조회 실패', error);
-  }
+  const res = await instance.get(`/dept/${hospitalId}/list`);
+  return res.data;
 };

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -184,6 +184,12 @@ export interface ModalBtnProps {
   handler: () => void;
 }
 
+export interface ModalState {
+  isOpen: boolean;
+  title: string;
+  content: JSX.Element | string;
+}
+
 // 사이드바
 export interface MenuItemProps {
   to: string;
@@ -222,4 +228,11 @@ export interface DeptDecode {
 
 export interface DeptNameDecode {
   [key: number]: string;
+}
+
+// Alert
+export interface AlertState {
+  isOpen: boolean;
+  content: JSX.Element | string;
+  type: string;
 }

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useState } from 'react';
+import { useRecoilState } from 'recoil';
 import { useNavigate } from 'react-router';
 import { getSchedule } from '@/lib/api';
-import { Schedule } from '@/lib/types';
+import { Schedule, AlertState } from '@/lib/types';
 import { CALENDAR_TEXTS } from '@/constants/calendar';
+import { alertState } from '@/states/stateAlert';
 import CalendarBody from '@/components/Calendar/CalendarBody';
 import CalendarList from '@/components/Calendar/CalendarList';
 import Loading from '@/components/Loading';
+import Alert from '@/components/Alert';
 import dayjs from 'dayjs';
 import styled from 'styled-components';
 
@@ -17,14 +20,27 @@ const Calendar = () => {
   const [annualActive, setAnnualActive] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
+  const [, setAlert] = useRecoilState<AlertState>(alertState);
+
   const navigate = useNavigate();
   const weekDays = ['일', '월', '화', '수', '목', '금', '토'];
 
   const fetchData = async () => {
-    setIsLoading(true);
-    const data = await getSchedule();
-    setScheduleData(data.item);
-    setIsLoading(false);
+    try {
+      setIsLoading(true);
+      const res = await getSchedule();
+      if (res.success) {
+        setScheduleData(res.item);
+      }
+    } catch (error) {
+      setAlert({
+        isOpen: true,
+        content: `메인 캘린더 조회 실패\n${error}`,
+        type: 'error',
+      });
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   useEffect(() => {
@@ -62,6 +78,7 @@ const Calendar = () => {
   return (
     <Container>
       {isLoading && <Loading />}
+      <Alert />
       <ToggleButton>
         <Button
           className={toggleButton ? 'calendar-button active' : 'calendar-button'}

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { useNavigate } from 'react-router';
 import { getSchedule } from '@/lib/api';
 import { Schedule, AlertState } from '@/lib/types';
@@ -20,7 +20,7 @@ const Calendar = () => {
   const [annualActive, setAnnualActive] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
-  const [, setAlert] = useRecoilState<AlertState>(alertState);
+  const setAlert = useSetRecoilState<AlertState>(alertState);
 
   const navigate = useNavigate();
   const weekDays = ['일', '월', '화', '수', '목', '금', '토'];

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -42,10 +42,10 @@ const Login = () => {
       });
     } else {
       try {
-        const response = await login({ email: data.email, password: data.password });
-        if (response && response.data.success) {
+        const res = await login({ email: data.email, password: data.password });
+        if (res && res.data.success) {
           setLoginError('');
-          const token = response.headers.authorization;
+          const token = res.headers.authorization;
           saveTokenToLocalstorage(token);
           navigate('/');
         } else {

--- a/src/pages/Password.tsx
+++ b/src/pages/Password.tsx
@@ -2,10 +2,13 @@ import { useForm } from 'react-hook-form';
 import { PWValidation } from '@/lib/Validation';
 import { editPassword, logout } from '@/lib/api';
 import { useNavigate } from 'react-router';
+import { useRecoilState } from 'recoil';
+import { alertState } from '@/states/stateAlert';
 import { FiAlertCircle } from 'react-icons/fi';
-import { EditPasswordBody, EditPasswordForm } from '@/lib/types';
+import { EditPasswordBody, EditPasswordForm, AlertState } from '@/lib/types';
 import { PW_TEXTS } from '@/constants/password';
 import Btn from '@/components/Buttons/Btn';
+import Alert from '@/components/Alert';
 import styled from 'styled-components';
 
 const UserInfo = () => {
@@ -15,6 +18,8 @@ const UserInfo = () => {
     watch,
     formState: { errors },
   } = useForm<EditPasswordForm>({ mode: 'onChange' });
+
+  const [, setAlert] = useRecoilState<AlertState>(alertState);
 
   const navigate = useNavigate();
 
@@ -28,18 +33,27 @@ const UserInfo = () => {
     try {
       const res = await editPassword(body);
       if (res.success) {
-        alert(PW_TEXTS.success);
-        logout();
+        setAlert({
+          isOpen: true,
+          content: PW_TEXTS.success,
+          type: 'error',
+        });
+        await logout();
         localStorage.removeItem('authToken');
         navigate('/login');
       }
     } catch (error) {
-      console.error('비밀번호 변경 실패', error);
+      setAlert({
+        isOpen: true,
+        content: `비밀번호 변경 실패\n${error}`,
+        type: 'error',
+      });
     }
   };
 
   return (
     <Container>
+      <Alert />
       <Title>
         <h2>{PW_TEXTS.title}</h2>
       </Title>

--- a/src/pages/Password.tsx
+++ b/src/pages/Password.tsx
@@ -2,7 +2,7 @@ import { useForm } from 'react-hook-form';
 import { PWValidation } from '@/lib/Validation';
 import { editPassword, logout } from '@/lib/api';
 import { useNavigate } from 'react-router';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { alertState } from '@/states/stateAlert';
 import { FiAlertCircle } from 'react-icons/fi';
 import { EditPasswordBody, EditPasswordForm, AlertState } from '@/lib/types';
@@ -19,7 +19,7 @@ const UserInfo = () => {
     formState: { errors },
   } = useForm<EditPasswordForm>({ mode: 'onChange' });
 
-  const [, setAlert] = useRecoilState<AlertState>(alertState);
+  const setAlert = useSetRecoilState<AlertState>(alertState);
 
   const navigate = useNavigate();
 

--- a/src/pages/RequestList.tsx
+++ b/src/pages/RequestList.tsx
@@ -5,7 +5,7 @@ import { UserDataState } from '@/states/stateUserdata';
 import { getCategory } from '@/utils/getCategory';
 import { getEvaluation } from '@/utils/getEvaluation';
 import { useEffect, useState } from 'react';
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { RequestModal } from '@/components/Modals/RequestModal';
 import { AlertState, Request } from '@/lib/types';
 import { alertState } from '@/states/stateAlert';
@@ -18,7 +18,7 @@ import styled from 'styled-components';
 const RequestList = () => {
   const userDataState = useRecoilValue(UserDataState);
   const setScheduleId = useSetRecoilState(scheduleIdState);
-  const [, setAlert] = useRecoilState<AlertState>(alertState);
+  const setAlert = useSetRecoilState<AlertState>(alertState);
 
   const userID = userDataState.id;
 

--- a/src/pages/RequestList.tsx
+++ b/src/pages/RequestList.tsx
@@ -5,36 +5,52 @@ import { UserDataState } from '@/states/stateUserdata';
 import { getCategory } from '@/utils/getCategory';
 import { getEvaluation } from '@/utils/getEvaluation';
 import { useEffect, useState } from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { RequestModal } from '@/components/Modals/RequestModal';
-import { Request } from '@/lib/types';
+import { AlertState, Request } from '@/lib/types';
+import { alertState } from '@/states/stateAlert';
 import { REQUEST_LIST_TEXTS } from '@/constants/requestList';
 import Loading from '@/components/Loading';
+import Alert from '@/components/Alert';
 import CheckModal from '@/components/Modals/checkModal';
 import styled from 'styled-components';
 
 const RequestList = () => {
   const userDataState = useRecoilValue(UserDataState);
-  const userID = userDataState.id;
   const setScheduleId = useSetRecoilState(scheduleIdState);
+  const [, setAlert] = useRecoilState<AlertState>(alertState);
+
+  const userID = userDataState.id;
+
   const [requestLists, setRequestLists] = useState<Request[]>([]);
   const [isLoading, setIsLoading] = useState(false);
-  const { openModal } = useModal();
   const [sortBy, setSortBy] = useState('최신순');
 
+  const { openModal } = useModal();
+
   useEffect(() => {
-    setIsLoading(true);
     const getList = async () => {
-      const res = await getRequest(userID);
-      const sortedItems = Object.values(res.item) as Request[];
-      if (sortBy === REQUEST_LIST_TEXTS.latest) {
-        sortedItems.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
-      } else if (sortBy === REQUEST_LIST_TEXTS.oldest) {
-        sortedItems.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+      try {
+        setIsLoading(true);
+        const res = await getRequest(userID);
+        const sortedItems = Object.values(res.item) as Request[];
+        if (sortBy === REQUEST_LIST_TEXTS.latest) {
+          sortedItems.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+        } else if (sortBy === REQUEST_LIST_TEXTS.oldest) {
+          sortedItems.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+        }
+        setRequestLists(sortedItems);
+      } catch (error) {
+        setAlert({
+          isOpen: true,
+          content: `요청 내역 확인 실패\n${error}`,
+          type: 'error',
+        });
+      } finally {
+        setIsLoading(false);
       }
-      setRequestLists(sortedItems);
-      setIsLoading(false);
     };
+
     getList();
   }, [userID, sortBy]);
 
@@ -101,8 +117,10 @@ const RequestList = () => {
   const handleSortChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setSortBy(e.target.value);
   };
+
   return (
     <Container>
+      <Alert />
       {isLoading && <Loading />}
       <Header>
         <h1>{REQUEST_LIST_TEXTS.title}</h1>

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router';
+import { useRecoilState } from 'recoil';
+import { alertState } from '@/states/stateAlert';
 import { getHospitalList, getDeptList, signUp } from '@/lib/api';
 import {
   emailValidation,
@@ -11,18 +13,21 @@ import {
   deptValidation,
 } from '@/lib/Validation';
 import { FiAlertCircle } from 'react-icons/fi';
-import { SignUpForm, Hospital, Department } from '@/lib/types';
+import { SignUpForm, Hospital, Department, AlertState } from '@/lib/types';
 import { SIGN_UP_TEXTS } from '@/constants/signup';
 import backgroundLogo from '/backgroundlogo.png';
 import logowhithtext from '/logowithtext.png';
 import Btn from '@/components/Buttons/Btn';
+import Alert from '@/components/Alert';
 import styled from 'styled-components';
 
 const SignUp = () => {
   const [hospitalList, setHospitalList] = useState<string[]>([]);
-  const [hospitalInfo, setHospitalInfo] = useState<Hospital[]>([]); // 타입 변경
+  const [hospitalInfo, setHospitalInfo] = useState<Hospital[]>([]);
   const [hospitalDeptList, setHospitalDeptList] = useState<string[]>([]);
-  const [hospitalDeptInfo, setHospitalDeptInfo] = useState<Department[]>([]); // 타입 변경
+  const [hospitalDeptInfo, setHospitalDeptInfo] = useState<Department[]>([]);
+
+  const [, setAlert] = useRecoilState<AlertState>(alertState);
 
   const {
     register,
@@ -43,7 +48,11 @@ const SignUp = () => {
         setHospitalList(hospitalNames);
       }
     } catch (error) {
-      console.error('병원 리스트 조회 실패', error);
+      setAlert({
+        isOpen: true,
+        content: `병원 리스트 조회 실패\n${error}`,
+        type: 'error',
+      });
     }
   };
 
@@ -61,7 +70,11 @@ const SignUp = () => {
           setHospitalDeptList(deptList);
         }
       } catch (error) {
-        console.error('병원 과 리스트 조회 실패', error);
+        setAlert({
+          isOpen: true,
+          content: `병원 과 리스트 조회 실패\n${error}`,
+          type: 'error',
+        });
       }
     }
   };
@@ -107,12 +120,17 @@ const SignUp = () => {
         }
       }
     } catch (error) {
-      console.error('회원가입 실패', error);
+      setAlert({
+        isOpen: true,
+        content: `회원가입 실패\n${error}`,
+        type: 'error',
+      });
     }
   };
 
   return (
     <Container>
+      <Alert />
       <ImgContainer1 />
       <TextWrap>
         <span>{SIGN_UP_TEXTS.title}</span>

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { alertState } from '@/states/stateAlert';
 import { getHospitalList, getDeptList, signUp } from '@/lib/api';
 import {
@@ -27,7 +27,7 @@ const SignUp = () => {
   const [hospitalDeptList, setHospitalDeptList] = useState<string[]>([]);
   const [hospitalDeptInfo, setHospitalDeptInfo] = useState<Department[]>([]);
 
-  const [, setAlert] = useRecoilState<AlertState>(alertState);
+  const setAlert = useSetRecoilState<AlertState>(alertState);
 
   const {
     register,

--- a/src/pages/UserInfo.tsx
+++ b/src/pages/UserInfo.tsx
@@ -26,11 +26,11 @@ const UserInfo = () => {
   const { VITE_BASE_URL } = import.meta.env;
 
   const [user] = useRecoilState<UserData>(UserDataState);
-  const [alert, setAlert] = useRecoilState<AlertState>(alertState);
+  const [, setAlert] = useRecoilState<AlertState>(alertState);
 
   const [passwordChecked, setPasswordChecked] = useState<boolean>(false);
-  const [imgPreview, setImgPreview] = useState(`${VITE_BASE_URL}${user.profileImageUrl}`);
-  const [isLoading, setIsLoading] = useState(false);
+  const [imgPreview, setImgPreview] = useState<string>(`${VITE_BASE_URL}${user.profileImageUrl}`);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const userImg = watch('originImage');
 
@@ -40,7 +40,11 @@ const UserInfo = () => {
       if (typeof file !== 'string') {
         setImgPreview(URL.createObjectURL(file));
       } else {
-        console.error(USER_INFO_TEXTS.errors.profileImg);
+        setAlert({
+          isOpen: true,
+          content: USER_INFO_TEXTS.errors.profileImg,
+          type: 'error',
+        });
       }
     }
   }, [userImg]);
@@ -55,11 +59,21 @@ const UserInfo = () => {
     try {
       setIsLoading(true);
       const res = await login(body);
-      if (res?.status === 200) {
+      if (res.data.success) {
         setPasswordChecked(!passwordChecked);
+      } else {
+        setAlert({
+          isOpen: true,
+          content: `비밀번호 재확인 실패\n다시 한 번 시도해 주세요.`,
+          type: 'error',
+        });
       }
     } catch (error) {
-      console.error(USER_INFO_TEXTS.errors.failCheckPW, error);
+      setAlert({
+        isOpen: true,
+        content: `비밀번호 재확인 실패\n${error}`,
+        type: 'error',
+      });
     } finally {
       setIsLoading(false);
     }
@@ -93,7 +107,12 @@ const UserInfo = () => {
 
         reader.readAsDataURL(file);
         return await base64Promise;
-      } else return alert(USER_INFO_TEXTS.errors.profileImgFileSize);
+      } else
+        setAlert({
+          isOpen: true,
+          content: USER_INFO_TEXTS.errors.profileImgFileSize,
+          type: 'error',
+        });
     };
 
     const image = await photoBase64Handler(originImage[0]);
@@ -111,11 +130,19 @@ const UserInfo = () => {
         setIsLoading(true);
         const res = await editMyPage(body);
         if (res.success) {
-          alert('개인정보 수정이 완료되었습니다.');
+          setAlert({
+            isOpen: true,
+            content: '개인정보 수정이 완료되었습니다.',
+            type: 'error',
+          });
           location.reload();
         }
       } catch (error) {
-        console.error('개인정보 수정 실패', error);
+        setAlert({
+          isOpen: true,
+          content: `개인정보 수정 실패\n${error}`,
+          type: 'error',
+        });
       } finally {
         setIsLoading(false);
       }

--- a/src/pages/UserInfo.tsx
+++ b/src/pages/UserInfo.tsx
@@ -1,16 +1,18 @@
 import { useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { hospitalDecode } from '@/utils/decode';
-import { LoginBody, UserData } from '@/lib/types';
+import { LoginBody, UserData, AlertState } from '@/lib/types';
 import { PWValidation, nameValidation, phoneValidation } from '@/lib/Validation';
-import { UserDataState } from '@/states/stateUserdata';
 import { useRecoilState } from 'recoil';
+import { UserDataState } from '@/states/stateUserdata';
+import { alertState } from '@/states/stateAlert';
 import { login, editMyPage } from '@/lib/api';
 import { FiAlertCircle } from 'react-icons/fi';
 import { ProfileBody, Password, DeptDecode } from '@/lib/types';
 import { USER_INFO_TEXTS } from '@/constants/userInfo';
 import Loading from '@/components/Loading';
 import Btn from '@/components/Buttons/Btn';
+import Alert from '@/components/Alert';
 import styled from 'styled-components';
 
 const UserInfo = () => {
@@ -24,6 +26,7 @@ const UserInfo = () => {
   const { VITE_BASE_URL } = import.meta.env;
 
   const [user] = useRecoilState<UserData>(UserDataState);
+  const [alert, setAlert] = useRecoilState<AlertState>(alertState);
 
   const [passwordChecked, setPasswordChecked] = useState<boolean>(false);
   const [imgPreview, setImgPreview] = useState(`${VITE_BASE_URL}${user.profileImageUrl}`);
@@ -121,6 +124,7 @@ const UserInfo = () => {
 
   return (
     <>
+      <Alert />
       {!passwordChecked ? (
         <PWCheckContainer>
           {isLoading && <Loading />}

--- a/src/pages/UserInfo.tsx
+++ b/src/pages/UserInfo.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form';
 import { hospitalDecode } from '@/utils/decode';
 import { LoginBody, UserData, AlertState } from '@/lib/types';
 import { PWValidation, nameValidation, phoneValidation } from '@/lib/Validation';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import { UserDataState } from '@/states/stateUserdata';
 import { alertState } from '@/states/stateAlert';
 import { login, editMyPage } from '@/lib/api';
@@ -26,7 +26,7 @@ const UserInfo = () => {
   const { VITE_BASE_URL } = import.meta.env;
 
   const [user] = useRecoilState<UserData>(UserDataState);
-  const [, setAlert] = useRecoilState<AlertState>(alertState);
+  const setAlert = useSetRecoilState<AlertState>(alertState);
 
   const [passwordChecked, setPasswordChecked] = useState<boolean>(false);
   const [imgPreview, setImgPreview] = useState<string>(`${VITE_BASE_URL}${user.profileImageUrl}`);

--- a/src/states/stateAlert.ts
+++ b/src/states/stateAlert.ts
@@ -4,7 +4,7 @@ import { AlertState } from '@/lib/types';
 export const alertState = atom<AlertState>({
   key: 'alertState',
   default: {
-    isOpen: true,
+    isOpen: false,
     content: '',
     type: 'error',
   },

--- a/src/states/stateAlert.ts
+++ b/src/states/stateAlert.ts
@@ -1,0 +1,11 @@
+import { atom } from 'recoil';
+import { AlertState } from '@/lib/types';
+
+export const alertState = atom<AlertState>({
+  key: 'alertState',
+  default: {
+    isOpen: true,
+    content: '',
+    type: 'error',
+  },
+});

--- a/src/states/stateModal.ts
+++ b/src/states/stateModal.ts
@@ -1,12 +1,7 @@
 import { atom } from 'recoil';
+import { ModalState } from '@/lib/types';
 
-export type ModalType = {
-  isOpen: boolean;
-  title: string;
-  content: JSX.Element | string;
-};
-
-export const modalState = atom<ModalType>({
+export const modalState = atom<ModalState>({
   key: 'modalState',
   default: {
     isOpen: false,


### PR DESCRIPTION
## PR 타입

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 업데이트
- [x] 사소한 수정

<br />

## PR 요약

전역 사용 가능한 Alert 구현 및 console.error 대신 Alert 처리

![스크린샷 2023-11-01 오후 5 01 54](https://github.com/MINI-TEAM3/client/assets/116873887/460f9928-628f-43a5-b152-6d6220fde082)


<br />

## 변경사항

API 호출 코드 부분의 try catch가 사라지고 res 또는 res.data를 리턴하도록 수정했습니다.
각 API를 호출하는 컴포넌트 내부에서 try catch문이 사용되고, catch 안에서 에러 처리 시 Alert를 띄웁니다.

![스크린샷 2023-11-01 오후 5 02 00](https://github.com/MINI-TEAM3/client/assets/116873887/87ac3d3e-341e-419a-a38b-f710092f2cc8)

<br />

## 코드 참고사항

로그인 후 메인 캘린더 진입 시 에러 메세지가 뜨지 않는 Alert가 노출되는데 이 부분 오류를 못잡고 있습니다.
혹시 코드 보시다가 이유를 발견하시면 제보 부탁드려요 🥹