### PR TITLE
✨  Feat: 근무 관리 테이블 추가 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "mini3-client",
       "version": "0.0.0",
       "dependencies": {
+        "@ag-grid-community/core": "^30.2.1",
+        "ag-grid-community": "^30.2.1",
+        "ag-grid-react": "^30.2.1",
         "axios": "^1.4.0",
         "dayjs": "^1.11.9",
         "file-saver": "^2.0.5",
@@ -45,6 +48,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@ag-grid-community/core": {
+      "version": "30.2.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-community/core/-/core-30.2.1.tgz",
+      "integrity": "sha512-jGRBfRFsLwxch8GJGjbVI2FVbB+/fy1s4mm8//+kOkcPFlq4BbLFELvU4Kupwk1YkhduxUC50GTYyFzmF0rSIQ=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
@@ -2776,6 +2784,24 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/ag-grid-community": {
+      "version": "30.2.1",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-30.2.1.tgz",
+      "integrity": "sha512-1slonXskJbbI9ybhTx//4YKfJpZVAEnHL8dui1rQJRSXKByUi+/f7XtvkLsbgBkawoWbqvRAySjYtvz80+kBfA=="
+    },
+    "node_modules/ag-grid-react": {
+      "version": "30.2.1",
+      "resolved": "https://registry.npmjs.org/ag-grid-react/-/ag-grid-react-30.2.1.tgz",
+      "integrity": "sha512-WYt5ZstSoPEGAcTqXBdaonihXtapZdjTHZ3dc3xTK1xIdbF0/Vw4zDWCQSsG5H4M5CeUKjvbeHx7kKM1Yiah3g==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "ag-grid-community": "~30.2.1",
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.3.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -4179,6 +4205,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4367,6 +4401,16 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -4446,6 +4490,11 @@
       "peerDependencies": {
         "react": "*"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-refresh": {
       "version": "0.14.0",
@@ -5156,6 +5205,11 @@
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "dev": true
+    },
+    "@ag-grid-community/core": {
+      "version": "30.2.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-community/core/-/core-30.2.1.tgz",
+      "integrity": "sha512-jGRBfRFsLwxch8GJGjbVI2FVbB+/fy1s4mm8//+kOkcPFlq4BbLFELvU4Kupwk1YkhduxUC50GTYyFzmF0rSIQ=="
     },
     "@ampproject/remapping": {
       "version": "2.2.1",
@@ -6908,6 +6962,19 @@
       "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
       "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A=="
     },
+    "ag-grid-community": {
+      "version": "30.2.1",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-30.2.1.tgz",
+      "integrity": "sha512-1slonXskJbbI9ybhTx//4YKfJpZVAEnHL8dui1rQJRSXKByUi+/f7XtvkLsbgBkawoWbqvRAySjYtvz80+kBfA=="
+    },
+    "ag-grid-react": {
+      "version": "30.2.1",
+      "resolved": "https://registry.npmjs.org/ag-grid-react/-/ag-grid-react-30.2.1.tgz",
+      "integrity": "sha512-WYt5ZstSoPEGAcTqXBdaonihXtapZdjTHZ3dc3xTK1xIdbF0/Vw4zDWCQSsG5H4M5CeUKjvbeHx7kKM1Yiah3g==",
+      "requires": {
+        "prop-types": "^15.8.1"
+      }
+    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -7925,6 +7992,11 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "optional": true
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -8045,6 +8117,16 @@
       "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
       "dev": true
     },
+    "prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -8090,6 +8172,11 @@
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.10.1.tgz",
       "integrity": "sha512-/ngzDP/77tlCfqthiiGNZeYFACw85fUjZtLbedmJ5DTlNDIwETxhwBzdOJ21zj4iJdvc0J3y7yOsX3PpxAJzrw==",
       "requires": {}
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-refresh": {
       "version": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@ag-grid-community/core": "^30.2.1",
+    "ag-grid-community": "^30.2.1",
+    "ag-grid-react": "^30.2.1",
     "axios": "^1.4.0",
     "dayjs": "^1.11.9",
     "file-saver": "^2.0.5",

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -1,0 +1,211 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { AgGridReact } from 'ag-grid-react';
+import 'ag-grid-community/styles/ag-grid.css';
+import 'ag-grid-community/styles/ag-theme-alpine.css';
+import styled from 'styled-components';
+import { MdFirstPage, MdLastPage, MdChevronLeft, MdChevronRight } from 'react-icons/md';
+import { ColDef, GridReadyEvent, GridSizeChangedEvent } from 'ag-grid-community';
+import { ColumnData, GridTableProps } from '@/lib/types';
+
+let minRowHeight = 30;
+let currentRowHeight: number;
+
+const updateRowHeight = (params: GridSizeChangedEvent) => {
+  const bodyViewport = document.querySelector('.ag-body-viewport');
+  if (!bodyViewport) {
+    return;
+  }
+  const gridHeight = bodyViewport.clientHeight;
+  const renderedRowCount = params.api.getDisplayedRowCount();
+  if (renderedRowCount * minRowHeight >= gridHeight) {
+    if (currentRowHeight !== minRowHeight) {
+      currentRowHeight = minRowHeight;
+      params.api.resetRowHeights();
+    }
+  } else {
+    currentRowHeight = Math.floor(gridHeight / renderedRowCount);
+    params.api.resetRowHeights();
+  }
+};
+
+const createColumns = (columnsData: ColumnData[]) => {
+  return columnsData.map(columnData => {
+    const { headerName, field, flex, cellRenderer, filter } = columnData;
+    const colDef: ColDef = {
+      headerName,
+      field,
+      flex,
+      cellRenderer,
+      filter,
+      cellStyle: {
+        textAlign: 'center',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      },
+    };
+
+    return colDef;
+  });
+};
+
+const GridTable = (props: GridTableProps) => {
+  const gridRef = useRef<AgGridReact>(null);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [totalPage, setTotalPage] = useState(0);
+  const { rowData, columnsData } = props;
+  const columnDefs = createColumns(columnsData);
+
+  const defaultColDef = useMemo(() => {
+    return {
+      resizable: true,
+    };
+  }, []);
+
+  const getRowHeight = useCallback(() => {
+    return currentRowHeight;
+  }, []);
+
+  const onGridReady = useCallback((params: GridReadyEvent) => {
+    minRowHeight = params.api.getSizesForCurrentTheme().rowHeight;
+    currentRowHeight = minRowHeight;
+    params.api.sizeColumnsToFit();
+
+    if (gridRef.current) {
+      setCurrentPage(gridRef.current.api.paginationGetCurrentPage() + 1);
+      setTotalPage(gridRef.current.api.paginationGetTotalPages());
+    }
+  }, []);
+
+  const onGridSizeChanged = useCallback((params: GridSizeChangedEvent) => {
+    updateRowHeight(params);
+    params.api.sizeColumnsToFit();
+    if (gridRef.current) {
+      setCurrentPage(gridRef.current.api.paginationGetCurrentPage() + 1);
+      setTotalPage(gridRef.current.api.paginationGetTotalPages());
+    }
+  }, []);
+
+  const gridOptions = {
+    headerHeight: 50,
+    rowHeight: 30,
+  };
+
+  const onBtFirst = useCallback(() => {
+    if (gridRef.current) {
+      gridRef.current.api.paginationGoToFirstPage();
+      setCurrentPage(gridRef.current.api.paginationGetCurrentPage() + 1);
+    }
+  }, []);
+
+  const onBtLast = useCallback(() => {
+    if (gridRef.current) {
+      gridRef.current.api.paginationGoToLastPage();
+      setCurrentPage(gridRef.current.api.paginationGetCurrentPage() + 1);
+    }
+  }, []);
+
+  const onBtNext = useCallback(() => {
+    if (gridRef.current) {
+      gridRef.current.api.paginationGoToNextPage();
+      setCurrentPage(gridRef.current.api.paginationGetCurrentPage() + 1);
+    }
+  }, []);
+
+  const onBtPrevious = useCallback(() => {
+    if (gridRef.current) {
+      gridRef.current.api.paginationGoToPreviousPage();
+      setCurrentPage(gridRef.current.api.paginationGetCurrentPage() + 1);
+    }
+  }, []);
+
+  const onPaginationChanged = useCallback(() => {
+    if (gridRef.current && gridRef.current.api) {
+      setTotalPage(gridRef.current.api.paginationGetTotalPages());
+      setCurrentPage(gridRef.current.api.paginationGetCurrentPage() + 1);
+    }
+  }, []);
+
+  return (
+    <Container>
+      <div className="ag-theme-custom">
+        <AgGridReact
+          ref={gridRef}
+          rowData={rowData}
+          columnDefs={columnDefs}
+          defaultColDef={defaultColDef}
+          getRowHeight={getRowHeight}
+          gridOptions={gridOptions}
+          onGridReady={onGridReady}
+          onGridSizeChanged={onGridSizeChanged}
+          pagination={true}
+          suppressRowTransform={true}
+          paginationPageSize={10}
+          paginationAutoPageSize={true}
+          suppressPaginationPanel={true}
+          onPaginationChanged={onPaginationChanged}
+        />
+      </div>
+      <ButtonWrap>
+        <button onClick={onBtFirst}>
+          <MdFirstPage />
+        </button>
+        <button onClick={onBtPrevious}>
+          <MdChevronLeft />
+        </button>
+        <span>{gridRef.current && currentPage + '/' + totalPage}</span>
+        <button onClick={onBtNext}>
+          <MdChevronRight />
+        </button>
+        <button onClick={onBtLast}>
+          <MdLastPage />
+        </button>
+      </ButtonWrap>
+    </Container>
+  );
+};
+
+export default GridTable;
+
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  .ag-theme-custom {
+    width: 100%;
+    height: 100%;
+    --ag-row-border-width: 0px;
+    .ag-header-cell-label {
+      justify-content: center;
+    }
+    margin: 0;
+  }
+`;
+
+const ButtonWrap = styled.div`
+  width: 100%;
+  display: flex;
+  padding: 10px 0 0 0;
+  align-items: center;
+  justify-content: center;
+  button {
+    width: 32px;
+    height: 32px;
+    background-color: transparent;
+    border: none;
+    font-size: 1.125rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: ${props => props.theme.primary};
+    &:disabled {
+      color: ${props => props.theme.lightGray};
+    }
+  }
+  span {
+    padding: 0 10px 0 10px;
+    color: ${props => props.theme.primary};
+  }
+`;

--- a/src/constants/attendance.ts
+++ b/src/constants/attendance.ts
@@ -1,3 +1,40 @@
+import { convertTime } from '@/utils/convertTime';
+import { splitTimeStamp } from '@/utils/splitTimestamp';
+import { ICellRendererParams } from 'ag-grid-community';
 export const ATTENDANCE_TEXTS = Object.freeze({
   title: '근무 관리',
 });
+
+export const ATTENDANCE_COLUMN = [
+  {
+    headerName: '출근 날짜',
+    field: 'startTime',
+    flex: 1,
+    cellRenderer: (params: ICellRendererParams) => splitTimeStamp(params.value, 'date'),
+  },
+  {
+    headerName: '출근 시간',
+    field: 'startTime',
+    flex: 1,
+    cellRenderer: (params: ICellRendererParams) => splitTimeStamp(params.value, 'hh:mm'),
+  },
+  {
+    headerName: '퇴근 날짜',
+    field: 'endTime',
+    flex: 1,
+    filter: true,
+    cellRenderer: (params: ICellRendererParams) => splitTimeStamp(params.value, 'date'),
+  },
+  {
+    headerName: '퇴근 시간',
+    field: 'endTime',
+    flex: 1,
+    cellRenderer: (params: ICellRendererParams) => splitTimeStamp(params.value, 'hh:mm'),
+  },
+  {
+    headerName: '금일 근로시간',
+    field: 'workTime',
+    flex: 1,
+    cellRenderer: (params: ICellRendererParams) => convertTime(params.value),
+  },
+];

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,3 +1,5 @@
+import { ICellRendererParams } from 'ag-grid-community';
+
 // 프로젝트에 사용되는 types 정리 //
 
 // 사용자 데이터
@@ -239,4 +241,36 @@ export interface AlertState {
   isOpen: boolean;
   content: JSX.Element | string;
   type: string;
+}
+
+// Table
+// 근무관리 목록
+export interface AttendanceList {
+  startTime: string;
+  endTime: string;
+  workTime: string;
+}
+
+// ag grid 셀 스타일
+export interface cellStyleType {
+  textAlign: string;
+  display: string;
+  alignItems: string;
+  justifyContent: string;
+}
+
+// ag grid 컬럼
+export interface ColumnData {
+  headerName: string;
+  field: string;
+  flex: number;
+  cellStyle?: cellStyleType;
+  cellRenderer?: (params: ICellRendererParams) => React.ReactNode;
+  filter?: boolean;
+}
+
+// ag grid 컴포넌트
+export interface GridTableProps {
+  rowData: AttendanceList[];
+  columnsData: ColumnData[];
 }

--- a/src/pages/Attendance.tsx
+++ b/src/pages/Attendance.tsx
@@ -3,11 +3,12 @@ import { useSetRecoilState } from 'recoil';
 import { getAttendance } from '@/lib/api';
 import { AlertState } from '@/lib/types';
 import { alertState } from '@/states/stateAlert';
-import { ATTENDANCE_TEXTS } from '@/constants/attendance';
+import { ATTENDANCE_TEXTS, ATTENDANCE_COLUMN } from '@/constants/attendance';
 import { convertDay } from '@/utils/convertDay';
 import Loading from '@/components/Loading';
 import Alert from '@/components/Alert';
 import DashBoard from '@/components/DashBoard';
+import GridTable from '@/components/Table/GridTable';
 import styled from 'styled-components';
 
 const Attendance = () => {
@@ -16,6 +17,7 @@ const Attendance = () => {
     weekWork: '0:00:00',
     monthWork: '0:00:00',
   });
+  const [tableData, setTableData] = useState([]);
   const [date, setDate] = useState('0000년 00월 00일 (0)');
   const [isLoading, setIsLoading] = useState(false);
 
@@ -28,6 +30,7 @@ const Attendance = () => {
       const res = await getAttendance();
       if (res.success) {
         setDashBoardData(res.item);
+        setTableData(res.item.works);
       }
     } catch (error) {
       setAlert({
@@ -66,6 +69,7 @@ const Attendance = () => {
         <SubTitle>{date}</SubTitle>
       </TitleContainer>
       <DashBoard data={dashBoardData} />
+      {tableData && <GridTable rowData={tableData} columnsData={ATTENDANCE_COLUMN} />}
     </Container>
   );
 };
@@ -76,6 +80,10 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   padding: 0 70px 40px 70px;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  gap: 20px;
 `;
 
 const TitleContainer = styled.div`
@@ -87,6 +95,7 @@ const Title = styled.div`
   display: flex;
   h2 {
     font-weight: 600;
+    margin: 0;
   }
 `;
 

--- a/src/utils/splitTimestamp.ts
+++ b/src/utils/splitTimestamp.ts
@@ -1,0 +1,21 @@
+/**
+ * yyyy-mm-ddThh:mm:ss 형식의 시간 데이터를 분리합니다.
+ * @param data (yyyy-mm-ddThh:mm:ss)
+ * @returns (yyyy-mm-dd,hh:mm:ss, hh:mm)
+ */
+export const splitTimeStamp = (time: string, type: string) => {
+  if (time === null) return '-';
+  const data = time.split('T');
+
+  if (type === 'date') {
+    return data[0];
+  } else if (type === 'hh:mm:ss') {
+    return data[1];
+  } else if (type === 'hh:mm') {
+    const timePattern = /(\d{2,3}:\d{2}):\d{2}/;
+    const match = data[1].match(timePattern);
+    if (match && match[1]) {
+      return match[1];
+    }
+  }
+};


### PR DESCRIPTION
## PR 타입

- [x] 기능 추가
- [ ] 버그 수정
- [x] 코드 업데이트
- [ ] 사소한 수정

<br />

## PR 요약

근무 관리 페이지에 테이블을 추가했습니다. 

![image](https://github.com/MINI-TEAM3/client/assets/100559990/378c36da-c86b-4c9d-ae31-3112d71424af)

ag-grid 라이브러리를 설치 했습니다. 
pull 이후 `npm install `이 필요합니다! 

<br />

## 변경사항

1. 테이블 관련 타입을 타입 파일에 추가했습니다. 
2. 테이블 출력용 시간 변환 유틸 함수를 추가했습니다. 
3. 테이블 삽입을 위해 Attendance 페이지 style을 수정했습니다. (높이, 너비, box-sizing, gap 설정) 

<br />

## 코드 참고사항

현재 출근중일때 (퇴근 시간 이 null일때) 사용자 피그마 상에는 빈 값인 경우가 없어서 
관리자와 동일하게 `-` 로 출력되도록 작성했습니다. 
출력값 변경 필요시 말씀주세요! 

이후 시간적여유가 생긴다면 출근 또는 퇴근 시간순으로 정렬 기능 추가 예정입니다! 
(api 없어도  라이브러리 자체로 구현 가능할 것 같습니다.) 